### PR TITLE
fix: Adjust streaming format and add LangSmith env var logging

### DIFF
--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -1,10 +1,12 @@
 # backend/app/api/v1/endpoints/chat.py
+import logging
+import json # New import
 from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
-from backend.app.schemas.chat_schemas import ChatRequest
-from backend.app.services.llm_service import LLMService
-# typing.AsyncGenerator is not needed here anymore for Python 3.9+
+from app.schemas.chat_schemas import ChatRequest
+from app.services.llm_service import LLMService
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 def get_llm_service():
@@ -15,17 +17,41 @@ async def handle_chat_streaming(
     request: ChatRequest,
     llm_service: LLMService = Depends(get_llm_service)
 ):
+    logger.info("Received chat request. Message count: %d", len(request.messages))
     if not request.messages:
+        logger.warning("Chat request received with no messages.")
         async def empty_response_stream():
-            yield "Could I BE any more confused? You didn't say anything!"
+            # Format even empty/error messages according to the protocol if expected client-side
+            # For consistency, let's format it.
+            error_payload = json.dumps("Could I BE any more confused? You didn't say anything!")
+            yield f"0:{error_payload}\n" # Protocol for text chunk
         return StreamingResponse(empty_response_stream(), media_type="text/plain")
 
     current_user_input = request.messages[-1].content
-    image_notes = request.image_context_notes # Extract image_context_notes
+    image_notes = request.image_context_notes
 
-    response_generator = llm_service.async_generate_streaming_response(
+    logger.debug("Current user input: '%.100s...', Image notes: '%s'", current_user_input, image_notes)
+
+    raw_token_generator = llm_service.async_generate_streaming_response(
         user_input=current_user_input,
-        image_notes=image_notes # Pass it to the service
+        image_notes=image_notes
     )
 
-    return StreamingResponse(response_generator, media_type="text/plain")
+    async def sdk_formatted_stream_generator():
+        """Wraps the raw token generator to format tokens for Vercel AI SDK."""
+        idx = 0 # Keep track of message index for potential future use, though 0 is for text stream
+        async for token in raw_token_generator:
+            if token is not None: # Ensure token is not None (can be empty string)
+                # JSON stringify the token itself to handle special characters within the token
+                json_stringified_token = json.dumps(token)
+                # Format according to Vercel AI SDK protocol for text chunks: 0:"<json_stringified_token_content>"
+                # The prefix '0:' indicates a text chunk. Other prefixes are for other data types.
+                formatted_chunk = f"0:{json_stringified_token}\n"
+                # Using %r for formatted_chunk to see escape sequences if any, strip for cleaner log
+                logger.debug("Yielding formatted chunk: %r", formatted_chunk.strip())
+                yield formatted_chunk
+                idx +=1
+            else:
+                logger.debug("Skipping None token from raw_token_generator")
+
+    return StreamingResponse(sdk_formatted_stream_generator(), media_type="text/plain")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     LANGCHAIN_TRACING_V2: str = "true"
     LANGCHAIN_ENDPOINT: str = "https://api.smith.langchain.com"
     LANGCHAIN_PROJECT: Optional[str] = "Chatterbox-Dev" # Default project name
+        LANGCHAIN_VERBOSE: bool = False # New setting for chain verbosity
 
     # LLM Service Provider: "GEMINI" or "LLAMA" (for future use)
     LLM_SERVICE_PROVIDER: str = "GEMINI"

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -1,0 +1,39 @@
+# backend/app/core/logging_config.py
+import logging
+import sys
+
+def setup_logging(log_level=logging.INFO):
+    """Configures basic logging for the application."""
+
+    # Define a basic log format
+    log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+    # Get the root logger
+    logger = logging.getLogger()
+
+    # Remove any existing handlers to avoid duplicate logs if reconfigured
+    if logger.hasHandlers():
+        logger.handlers.clear()
+
+    # Configure the root logger
+    logging.basicConfig(
+        level=log_level,
+        format=log_format,
+        handlers=[
+            logging.StreamHandler(sys.stdout) # Log to stdout
+            # You can add FileHandler here if you want to log to a file
+            # logging.FileHandler("app.log"),
+        ]
+    )
+
+    # You might want to set different levels for specific loggers, e.g.:
+    # logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
+    # logging.getLogger("langchain").setLevel(logging.INFO)
+
+# To test the logging setup (optional)
+if __name__ == "__main__":
+    setup_logging(logging.DEBUG)
+    logging.debug("Debug message from logging_config")
+    logging.info("Info message from logging_config")
+    logging.warning("Warning message from logging_config")
+    logging.error("Error message from logging_config")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,33 @@
 # backend/app/main.py
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from backend.app.api.v1.endpoints import chat as chat_router_v1
-# Import other routers as you create them
+from app.api.v1.endpoints import chat as chat_router_v1
+from app.core.logging_config import setup_logging
+from app.core.config import settings # Import settings
+import logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+# Log LangSmith configuration (excluding API key) for verification
+logger.info("--- LangSmith Configuration Verification ---")
+logger.info(f"LANGCHAIN_TRACING_V2: {settings.LANGCHAIN_TRACING_V2}")
+logger.info(f"LANGCHAIN_ENDPOINT: {settings.LANGCHAIN_ENDPOINT}")
+logger.info(f"LANGCHAIN_PROJECT: {settings.LANGCHAIN_PROJECT}")
+if settings.LANGCHAIN_API_KEY:
+    logger.info("LANGCHAIN_API_KEY is set (value not logged for security).")
+else:
+    logger.warning("LANGCHAIN_API_KEY is NOT set.")
+logger.info("--- End LangSmith Configuration Verification ---")
+# Also verify Google API Key presence
+if settings.GOOGLE_API_KEY:
+    logger.info("GOOGLE_API_KEY is set (value not logged for security).")
+else:
+    logger.warning("GOOGLE_API_KEY is NOT set. LLM calls will fail.")
+
 
 app = FastAPI(title="Chatterbox API", version="0.1.0")
+logger.info("FastAPI application starting up...")
 
 # CORS Middleware
 # Adjust origins as needed for your development and production environments
@@ -27,8 +50,10 @@ app.include_router(chat_router_v1.router, prefix="/api/v1", tags=["v1_chat"])
 
 @app.get("/")
 async def read_root():
+    logger.info("Root endpoint '/' was called.")
     return {"message": "Welcome to the Chatterbox API!"}
 
+logger.info("FastAPI application configured and ready.")
 # Placeholder for core/config.py content (will be created/used more in next steps)
 # from .core.config import settings
 # print(f"Settings loaded: {settings.APP_NAME}") # Example of using settings

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -1,12 +1,14 @@
 # backend/app/services/llm_service.py
-# (Imports and other parts of the class remain largely the same)
 import os
+import logging # New import
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain.prompts import ChatPromptTemplate, SystemMessagePromptTemplate, HumanMessagePromptTemplate, MessagesPlaceholder
 from langchain.chains import LLMChain
 from langchain.memory import ConversationBufferMemory
-from backend.app.core.config import settings
-from typing import AsyncGenerator, Optional # Added Optional
+from app.core.config import settings # Corrected import
+from typing import AsyncGenerator, Optional
+
+logger = logging.getLogger(__name__) # New logger instance
 
 def load_system_prompt():
     prompt_path = os.path.join(os.path.dirname(__file__), '..', 'prompts', 'chandler_bing.txt')
@@ -14,18 +16,19 @@ def load_system_prompt():
         with open(prompt_path, 'r') as f:
             return f.read()
     except FileNotFoundError:
-        print(f"Warning: Prompt file not found at {prompt_path}. Using default prompt.")
+        logger.warning(f"Prompt file not found at {prompt_path}. Using default prompt.") # Logging
         return "You are a helpful assistant. Please respond in a sarcastic tone."
 
 SYSTEM_PROMPT = load_system_prompt()
-# Global memory for now, acknowledge this needs to be session-specific in multi-user env
 memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True)
 
 class LLMService:
     def __init__(self):
         if not settings.GOOGLE_API_KEY:
+            logger.error("GOOGLE_API_KEY not found in environment variables.") # Logging
             raise ValueError("GOOGLE_API_KEY not found in environment variables.")
 
+        logger.info("Initializing ChatGoogleGenerativeAI with model: %s", "gemini-pro") # Logging
         self.llm = ChatGoogleGenerativeAI(
             model="gemini-pro",
             api_key=settings.GOOGLE_API_KEY,
@@ -36,46 +39,47 @@ class LLMService:
         self.prompt = ChatPromptTemplate.from_messages([
             SystemMessagePromptTemplate.from_template(SYSTEM_PROMPT),
             MessagesPlaceholder(variable_name="chat_history"),
-            HumanMessagePromptTemplate.from_template("{user_input_combined}") # Changed from user_input
+            HumanMessagePromptTemplate.from_template("{user_input_combined}")
         ])
 
         self.chain = LLMChain(
             llm=self.llm,
             prompt=self.prompt,
             memory=memory,
-            verbose=True
+            verbose=settings.LANGCHAIN_VERBOSE # Use a setting for verbose, default to False if not set
         )
+        logger.info("LLMService initialized successfully.") # Logging
 
     def _prepare_input_with_image_context(self, user_input: str, image_notes: Optional[str]) -> str:
         if image_notes:
-            return f"{user_input} [User has provided an image with the following context: {image_notes}]"
+            # Note: f-string evaluated immediately, so no sensitive data leak if image_notes is complex.
+            logger.debug("Adding image context notes: %s", image_notes) # Logging with %s
+            return f"{user_input} [Image context: {image_notes}]"
         return user_input
 
     async def generate_response(self, user_input: str, image_notes: Optional[str] = None, conversation_id: str = "default_conv"):
         combined_input = self._prepare_input_with_image_context(user_input, image_notes)
+        # Limiting logged input length
+        logger.info("Generating non-streaming response for input (post-image context): %.100s...", combined_input) # Logging
         try:
-            # Ensure the key matches the one in HumanMessagePromptTemplate.from_template
             result = self.chain.invoke({"user_input_combined": combined_input})
             response_text = result.get('text', "I seem to be at a loss for words... could this BE any more awkward?")
+            logger.info("Non-streaming response generated: %.100s...", response_text) # Logging
             return response_text
         except Exception as e:
-            print(f"Error during LLMChain invocation: {e}")
+            logger.error("Error during LLMChain invocation: %s", e, exc_info=True) # Logging with exc_info
             return "Uh oh, it seems my sarcasm circuits are a bit fried. Try again?"
 
     async def async_generate_streaming_response(self, user_input: str, image_notes: Optional[str] = None, conversation_id: str = "default_conv") -> AsyncGenerator[str, None]:
         combined_input = self._prepare_input_with_image_context(user_input, image_notes)
+        logger.info("Generating streaming response for input (post-image context): %.100s...", combined_input) # Logging
         try:
-            # Ensure the key matches the one in HumanMessagePromptTemplate.from_template
             async for chunk in self.chain.astream(input={"user_input_combined": combined_input}):
                 token = chunk.get("text")
                 if token:
+                    # logger.debug(f"Streamed token: {token}") # Can be too verbose
                     yield token
+            logger.info("Streaming response completed.") # Logging
         except Exception as e:
-            print(f"Error during LLMChain astream: {e}")
+            logger.error("Error during LLMChain astream: %s", e, exc_info=True) # Logging with exc_info
             yield "Oh, wow. My stream of consciousness just... stopped. Could this BE a server hiccup?"
-
-# Test functions (main_test, stream_test) would be here, commented out for brevity
-# if __name__ == "__main__":
-#     import asyncio
-#     # Define and run test functions if needed, ensuring they pass image_notes=None or some value.
-#     pass


### PR DESCRIPTION
- Step FS1: Adjust FastAPI Streaming Format for Frontend Compatibility
  - In `backend/app/api/v1/endpoints/chat.py`, I modified the stream generator to format chunks as `0:"<JSON_stringified_token>\n"` to align with Vercel AI SDK's expected protocol for text streams from external backends.
- Step FS2: Verify LangSmith Environment Variable Loading
  - In `backend/app/main.py`, I added logging at startup to display the status of LangSmith and Google API key related environment variables (excluding the keys themselves) to help verify your `.env` configuration.