### PR TITLE
debug: Add small delay in token streaming for frontend diagnosis

### DIFF
--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -1,6 +1,7 @@
 # backend/app/services/llm_service.py
 import os
-import logging # New import
+import logging
+import asyncio # New import
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain.prompts import ChatPromptTemplate, SystemMessagePromptTemplate, HumanMessagePromptTemplate, MessagesPlaceholder
 from langchain.chains import LLMChain
@@ -77,7 +78,8 @@ class LLMService:
             async for chunk in self.chain.astream(input={"user_input_combined": combined_input}):
                 token = chunk.get("text")
                 if token:
-                    # logger.debug(f"Streamed token: {token}") # Can be too verbose
+                    await asyncio.sleep(0.01) # Added small delay for debugging streaming
+                    # logger.debug("Streamed token: %s", token) # Can be too verbose
                     yield token
             logger.info("Streaming response completed.") # Logging
         except Exception as e:


### PR DESCRIPTION
debug: Add small delay in token streaming for frontend diagnosis

In `backend/app/services/llm_service.py`, within the `async_generate_streaming_response` method, an `await asyncio.sleep(0.01)` was added before yielding each token.

This is a diagnostic step to help determine if the frontend's rendering of the stream is affected by the rate at which tokens arrive. If tokens arrive too quickly, some UI frameworks or state management systems might batch updates, making it appear as if the entire response arrived at once. This change will help isolate that factor.

Output:
I've added a small delay in token streaming to help diagnose a frontend issue.

In `backend/app/services/llm_service.py`, within the `async_generate_streaming_response` method, I added an `await asyncio.sleep(0.01)` before yielding each token.

This is a diagnostic step to help determine if your frontend's rendering of the stream is affected by the rate at which tokens arrive. If tokens arrive too quickly, some UI frameworks or state management systems might batch updates, making it appear as if the entire response arrived at once. This change will help isolate that factor.