### PR TITLE
fix: Ensure .env loaded early for Langchain global config

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,32 +1,43 @@
 # backend/app/main.py
+import logging # Keep this early for logging setup
+from dotenv import load_dotenv # New import
+
+# Load environment variables from .env file as early as possible
+# This ensures os.environ is populated before other modules (like Langchain)
+# are imported and try to read from os.environ at their import time.
+load_dotenv()
+
+# Now proceed with other imports and setup
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.api.v1.endpoints import chat as chat_router_v1
 from app.core.logging_config import setup_logging
-from app.core.config import settings # Import settings
-import logging
+from app.core.config import settings # settings will now also see the pre-loaded env vars
 
+# Setup logging (uses settings, so after load_dotenv and settings import)
 setup_logging()
 logger = logging.getLogger(__name__)
 
 # Log LangSmith configuration (excluding API key) for verification
-logger.info("--- LangSmith Configuration Verification ---")
+logger.info("--- LangSmith Configuration Verification (main.py) ---")
 logger.info(f"LANGCHAIN_TRACING_V2: {settings.LANGCHAIN_TRACING_V2}")
 logger.info(f"LANGCHAIN_ENDPOINT: {settings.LANGCHAIN_ENDPOINT}")
 logger.info(f"LANGCHAIN_PROJECT: {settings.LANGCHAIN_PROJECT}")
-if settings.LANGCHAIN_API_KEY:
-    logger.info("LANGCHAIN_API_KEY is set (value not logged for security).")
+if settings.LANGCHAIN_API_KEY and settings.LANGCHAIN_API_KEY != "your_actual_langsmith_api_key": # Check if it's set and not the placeholder
+    logger.info("LANGCHAIN_API_KEY is set (value not logged).")
 else:
-    logger.warning("LANGCHAIN_API_KEY is NOT set.")
+    logger.warning("LANGCHAIN_API_KEY is NOT set or is placeholder.")
 logger.info("--- End LangSmith Configuration Verification ---")
+
 # Also verify Google API Key presence
-if settings.GOOGLE_API_KEY:
-    logger.info("GOOGLE_API_KEY is set (value not logged for security).")
+if settings.GOOGLE_API_KEY and settings.GOOGLE_API_KEY != "your_google_api_key": # Check if it's set and not the placeholder
+    logger.info("GOOGLE_API_KEY is set (value not logged).")
 else:
-    logger.warning("GOOGLE_API_KEY is NOT set. LLM calls will fail.")
+    logger.warning("GOOGLE_API_KEY is NOT set or is placeholder. LLM calls will fail.")
 
 
 app = FastAPI(title="Chatterbox API", version="0.1.0")
+# ... (rest of the file remains the same) ...
 logger.info("FastAPI application starting up...")
 
 # CORS Middleware


### PR DESCRIPTION
- In `backend/app/main.py`:
  - Called `load_dotenv()` from `python-dotenv` as the first executable line. This ensures `os.environ` is populated from the `.env` file before Langchain or other modules that might read environment variables at import time are loaded.
  - Updated startup logs to provide more specific warnings if API keys appear to be unset or are still default placeholder values.

This change aims to resolve issues where Langchain might not pick up LangSmith environment variables if they are not present in `os.environ` early enough during the application startup and module import process.