### PR TITLE
feat: Refactor memory with RunnableWithMessageHistory & add challenge…

### DIFF
--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -1,17 +1,26 @@
 # backend/app/services/llm_service.py
 import os
 import logging
-import asyncio
+# No longer need asyncio here directly unless for other async utilities not part of this core change
+# import asyncio
+
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain.prompts import ChatPromptTemplate, SystemMessagePromptTemplate, HumanMessagePromptTemplate, MessagesPlaceholder
-from langchain.memory import ConversationBufferMemory
-from langchain_core.output_parsers import StrOutputParser # New import
-# from langchain_core.runnables import RunnablePassthrough # If needed later
+# Remove ConversationBufferMemory import
+# from langchain.memory import ConversationBufferMemory
+
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.runnables.history import RunnableWithMessageHistory
+# Prefer in_memory from langchain_community if available as per common examples,
+# otherwise langchain_core.chat_history might be the path.
+# Let's assume langchain_community.chat_message_histories.in_memory.ChatMessageHistory for now.
+# If this specific path is an issue, the worker will try alternatives like `from langchain_core.chat_history import BaseChatMessageHistory, InMemoryChatMessageHistory`
+# and use InMemoryChatMessageHistory. For now, trying with the direct path often seen in examples.
+from langchain_community.chat_message_histories import ChatMessageHistory # New import
 
 from app.core.config import settings
 from typing import AsyncGenerator, Optional, Dict, Any, List
-from langchain_core.messages import BaseMessage, AIMessage, HumanMessage
-
+# BaseMessage, AIMessage, HumanMessage might not be directly needed here anymore if RunnableWithMessageHistory handles types
 
 logger = logging.getLogger(__name__)
 
@@ -25,17 +34,6 @@ def load_system_prompt():
         return "You are a helpful assistant. Please respond in a sarcastic tone."
 
 SYSTEM_PROMPT = load_system_prompt()
-
-# Global memory instance. This needs to be session-specific in a real multi-user app.
-# conversation_memory_store = {} # Example for session-specific, not implemented in this step
-
-# def get_session_memory(session_id: str) -> ConversationBufferMemory:
-#     if session_id not in conversation_memory_store:
-#         conversation_memory_store[session_id] = ConversationBufferMemory(
-#             memory_key="chat_history", return_messages=True
-#         )
-#     return conversation_memory_store[session_id]
-
 
 class LLMService:
     def __init__(self):
@@ -52,19 +50,31 @@ class LLMService:
 
         self.prompt = ChatPromptTemplate.from_messages([
             SystemMessagePromptTemplate.from_template(SYSTEM_PROMPT),
-            MessagesPlaceholder(variable_name="chat_history"),
-            HumanMessagePromptTemplate.from_template("{user_input_combined}")
+            MessagesPlaceholder(variable_name="chat_history"), # For RunnableWithMessageHistory
+            HumanMessagePromptTemplate.from_template("{user_input_combined}") # Input key for user message
         ])
 
-        # LCEL Runnable
-        self.runnable = self.prompt | self.llm | StrOutputParser()
+        core_runnable = self.prompt | self.llm | StrOutputParser()
 
-        # Global memory for this example. Refactor for session memory in production.
-        # For LCEL, memory management is often handled by composing runnables or explicitly passing history.
-        # This instance memory is for explicit loading/saving.
-        self.memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True)
+        # In-memory store for session histories
+        self.session_histories: Dict[str, ChatMessageHistory] = {}
 
-        logger.info("LLMService initialized with LCEL runnable and model %s.", "gemini-1.5-flash-latest")
+        self.runnable_with_history = RunnableWithMessageHistory(
+            core_runnable,
+            self.get_session_history, # Method to load/store session history
+            input_messages_key="user_input_combined", # Key for the user's current input
+            history_messages_key="chat_history", # Key for where history messages are injected into the prompt
+        )
+        logger.info("LLMService initialized with LCEL RunnableWithMessageHistory and model %s.", "gemini-1.5-flash-latest")
+
+    def get_session_history(self, session_id: str) -> ChatMessageHistory:
+        """Retrieves or creates an in-memory chat message history for a given session ID."""
+        if session_id not in self.session_histories:
+            logger.info(f"Creating new chat history for session_id: {session_id}")
+            self.session_histories[session_id] = ChatMessageHistory()
+        else:
+            logger.info(f"Using existing chat history for session_id: {session_id}")
+        return self.session_histories[session_id]
 
     def _prepare_input_with_image_context(self, user_input: str, image_notes: Optional[str]) -> str:
         if image_notes:
@@ -73,56 +83,37 @@ class LLMService:
         return user_input
 
     async def generate_response(self, user_input: str, image_notes: Optional[str] = None, conversation_id: str = "default_conv"):
-        # session_memory = get_session_memory(conversation_id) # Future session-specific memory
-        session_memory = self.memory # Using global memory for now
-
         combined_input = self._prepare_input_with_image_context(user_input, image_notes)
-        logger.info("Generating non-streaming LCEL response for input: %.100s...", combined_input)
-
-        loaded_memory = await asyncio.to_thread(session_memory.load_memory_variables, {})
-        chat_history_messages = loaded_memory.get("chat_history", [])
+        logger.info("Generating non-streaming LCEL response for input: %.100s... (session: %s)", combined_input, conversation_id)
 
         try:
-            response_text = await self.runnable.ainvoke({
-                "user_input_combined": combined_input,
-                "chat_history": chat_history_messages
-            })
-
-            await asyncio.to_thread(session_memory.save_context, {"input": combined_input}, {"output": response_text})
-
-            logger.info("Non-streaming LCEL response generated: %.100s...", response_text)
+            # RunnableWithMessageHistory handles history internally based on session_id in config
+            response_text = await self.runnable_with_history.ainvoke(
+                {"user_input_combined": combined_input},
+                config={"configurable": {"session_id": conversation_id}}
+            )
+            logger.info("Non-streaming LCEL response generated: %.100s... (session: %s)", response_text, conversation_id)
             return response_text
         except Exception as e:
-            logger.error("Error during LCEL runnable.ainvoke: %s", e, exc_info=True)
-            return "Uh oh, it seems my sarcasm circuits (LCEL edition) are a bit fried. Try again?"
+            logger.error("Error during LCEL runnable_with_history.ainvoke: %s (session: %s)", e, conversation_id, exc_info=True)
+            return "Uh oh, it seems my sarcasm circuits (LCEL+History edition) are a bit fried. Try again?"
 
     async def async_generate_streaming_response(
         self, user_input: str, image_notes: Optional[str] = None, conversation_id: str = "default_conv"
     ) -> AsyncGenerator[str, None]:
-        # session_memory = get_session_memory(conversation_id) # Future session-specific memory
-        session_memory = self.memory # Using global memory for now
-
         combined_input = self._prepare_input_with_image_context(user_input, image_notes)
-        logger.info("Generating streaming LCEL response for input: %.100s...", combined_input)
+        logger.info("Generating streaming LCEL response for input: %.100s... (session: %s)", combined_input, conversation_id)
 
-        loaded_memory = await asyncio.to_thread(session_memory.load_memory_variables, {})
-        chat_history_messages = loaded_memory.get("chat_history", [])
-
-        full_response_for_memory = []
         try:
-            async for token in self.runnable.astream({
-                "user_input_combined": combined_input,
-                "chat_history": chat_history_messages
-            }):
+            # RunnableWithMessageHistory handles history internally based on session_id in config
+            async for token in self.runnable_with_history.astream(
+                {"user_input_combined": combined_input},
+                config={"configurable": {"session_id": conversation_id}}
+            ):
+                # token here is already a string due to StrOutputParser
                 if token:
-                    # await asyncio.sleep(0.01) # Removed for now, was for debugging
-                    full_response_for_memory.append(token)
                     yield token
-
-            ai_response_str = "".join(full_response_for_memory)
-            await asyncio.to_thread(session_memory.save_context, {"input": combined_input}, {"output": ai_response_str})
-
-            logger.info("Streaming LCEL response completed.")
+            logger.info("Streaming LCEL response completed. (session: %s)", conversation_id)
         except Exception as e:
-            logger.error("Error during LCEL runnable.astream: %s", e, exc_info=True)
-            yield "Oh, wow. My LCEL stream of consciousness just... stopped. Could this BE a server hiccup?"
+            logger.error("Error during LCEL runnable_with_history.astream: %s (session: %s)", e, conversation_id, exc_info=True)
+            yield "Oh, wow. My LCEL (with History!) stream of consciousness just... stopped. Could this BE a server hiccup?"

--- a/challenges.md
+++ b/challenges.md
@@ -1,0 +1,43 @@
+# Project Challenges & Learnings
+
+This document logs some of the key technical challenges encountered during the development of the "Chatterbox" application and how they were addressed.
+
+## 1. Frontend Streaming Appearance (User Feedback Driven)
+
+*   **Challenge:** AI responses were appearing on the frontend all at once, instead of streaming token-by-token, despite using FastAPI's `StreamingResponse` and Langchain's `astream()`.
+*   **Initial Attempts:**
+    *   Added a small `asyncio.sleep(0.01)` between yielding tokens in the backend service. This did not resolve the visual issue.
+*   **Resolution / Key Learning:**
+    *   The Vercel AI SDK's `useChat` hook, when consuming streams from an external backend, can be particular about the stream format.
+    *   Explicitly formatting each yielded chunk from FastAPI as `0:"<JSON_stringified_token>\n"` (where the token itself is JSON stringified) proved effective. This aligns with a protocol the AI SDK uses for streaming text data.
+    *   Refactoring to Langchain Expression Language (LCEL) was done in parallel for modernization, which also inherently improved clarity of the streaming pipeline. The visual streaming started working after the LCEL refactor *and* the correct Vercel AI SDK stream formatting was in place.
+
+## 2. LangSmith Integration (User Feedback Driven)
+
+*   **Challenge:** LangSmith traces were not appearing in the dashboard despite setting the required `LANGCHAIN_...` environment variables in the `.env` file and `pydantic-settings` confirming they were loaded into the application's `settings` object.
+*   **Initial Attempts:**
+    *   Code reviews confirmed no explicit disabling of LangSmith.
+    *   Logging confirmed `settings` object in FastAPI had the correct LangSmith config values.
+*   **Resolution / Key Learning:**
+    *   Langchain's automatic pickup of environment variables for global features like LangSmith tracing can depend on `os.environ` being populated *before* Langchain modules are first imported (as they might read `os.environ` at import time).
+    *   Explicitly calling `load_dotenv()` from the `python-dotenv` package at the very beginning of `backend/app/main.py` (before other key imports like FastAPI, settings, or Langchain-related modules) resolved this. This ensured `os.environ` was populated early enough for Langchain's global state to initialize correctly with tracing enabled.
+
+## 3. Python Import Paths (User Feedback Driven)
+
+*   **Challenge:** When running the FastAPI server using `uvicorn app.main:app` from the `backend/` directory, `ModuleNotFoundError` occurred due to import paths like `from backend.app.services...`.
+*   **Resolution / Key Learning:**
+    *   Corrected all internal application imports within the `backend/app/` directory to be relative to the `app` package (e.g., `from app.services...`, `from app.core...`). This is standard practice when structuring a Python application that will be run with its root directory in `PYTHONPATH` or when using an entry point like `app.main:app`.
+
+## 4. Deprecated Langchain Features (Ongoing)
+
+*   **Challenge:** Encountered deprecation warnings for:
+    *   `LLMChain`: Indicated a shift towards Langchain Expression Language (LCEL).
+    *   `ConversationBufferMemory` (when used with LCEL in a specific way): Pointed to new patterns for integrating memory with LCEL runnables.
+    *   `convert_system_message_to_human` parameter in `ChatGoogleGenerativeAI`.
+*   **Resolution / Actions:**
+    *   `convert_system_message_to_human`: Addressed by removing the parameter and ensuring the system prompt was correctly positioned for the updated `ChatGoogleGenerativeAI` model (`gemini-1.5-flash-latest`).
+    *   `LLMChain`: Successfully refactored the core logic in `LLMService` to use LCEL (`prompt | llm | StrOutputParser()`).
+    *   `ConversationBufferMemory`: This is the next item to be addressed by refactoring to use `RunnableWithMessageHistory` as per Langchain's latest guidelines.
+
+---
+*This log will be updated as new challenges arise and are addressed.*


### PR DESCRIPTION
…s.md

- I documented challenges faced:
  - I created `challenges.md` in the project root.
  - I added initial content outlining key challenges encountered and resolved so far (streaming, LangSmith, import paths, deprecations).

- I refactored ConversationBufferMemory (addressing deprecation):
  - In `backend/app/services/llm_service.py`:
    - I replaced manual `ConversationBufferMemory` management with `RunnableWithMessageHistory` from `langchain_core.runnables.history`.
    - I implemented `get_session_history` method using an in-memory dictionary (`self.session_histories`) storing `ChatMessageHistory` instances per `session_id`.
    - The LCEL runnable is now wrapped with `RunnableWithMessageHistory`, automating history load/save based on `session_id` provided in the `config` of `ainvoke`/`astream` calls.
    - I removed manual history loading and saving code.

This commit addresses the `ConversationBufferMemory` deprecation warning and modernizes memory management to align with LCEL best practices. It also introduces `challenges.md` for project documentation.