### PR TITLE
feat: Add detailed logging for conversational memory

### DIFF
--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -1,30 +1,18 @@
 # backend/app/services/llm_service.py
 import os
 import logging
-# No longer need asyncio here directly unless for other async utilities not part of this core change
-# import asyncio
-
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain.prompts import ChatPromptTemplate, SystemMessagePromptTemplate, HumanMessagePromptTemplate, MessagesPlaceholder
-# Remove ConversationBufferMemory import
-# from langchain.memory import ConversationBufferMemory
-
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.runnables.history import RunnableWithMessageHistory
-# Prefer in_memory from langchain_community if available as per common examples,
-# otherwise langchain_core.chat_history might be the path.
-# Let's assume langchain_community.chat_message_histories.in_memory.ChatMessageHistory for now.
-# If this specific path is an issue, the worker will try alternatives like `from langchain_core.chat_history import BaseChatMessageHistory, InMemoryChatMessageHistory`
-# and use InMemoryChatMessageHistory. For now, trying with the direct path often seen in examples.
-from langchain_community.chat_message_histories import ChatMessageHistory # New import
-
+from langchain_community.chat_message_histories import ChatMessageHistory
 from app.core.config import settings
-from typing import AsyncGenerator, Optional, Dict, Any, List
-# BaseMessage, AIMessage, HumanMessage might not be directly needed here anymore if RunnableWithMessageHistory handles types
+from typing import AsyncGenerator, Optional, Dict
 
 logger = logging.getLogger(__name__)
 
 def load_system_prompt():
+    # ... (load_system_prompt remains the same)
     prompt_path = os.path.join(os.path.dirname(__file__), '..', 'prompts', 'chandler_bing.txt')
     try:
         with open(prompt_path, 'r') as f:
@@ -32,11 +20,11 @@ def load_system_prompt():
     except FileNotFoundError:
         logger.warning("Prompt file not found at %s. Using default prompt.", prompt_path)
         return "You are a helpful assistant. Please respond in a sarcastic tone."
-
 SYSTEM_PROMPT = load_system_prompt()
 
 class LLMService:
     def __init__(self):
+        # ... (LLM and prompt initialization remains the same)
         if not settings.GOOGLE_API_KEY:
             logger.error("GOOGLE_API_KEY not found in environment variables.")
             raise ValueError("GOOGLE_API_KEY not found in environment variables.")
@@ -50,33 +38,38 @@ class LLMService:
 
         self.prompt = ChatPromptTemplate.from_messages([
             SystemMessagePromptTemplate.from_template(SYSTEM_PROMPT),
-            MessagesPlaceholder(variable_name="chat_history"), # For RunnableWithMessageHistory
-            HumanMessagePromptTemplate.from_template("{user_input_combined}") # Input key for user message
+            MessagesPlaceholder(variable_name="chat_history"),
+            HumanMessagePromptTemplate.from_template("{user_input_combined}")
         ])
 
         core_runnable = self.prompt | self.llm | StrOutputParser()
-
-        # In-memory store for session histories
         self.session_histories: Dict[str, ChatMessageHistory] = {}
 
         self.runnable_with_history = RunnableWithMessageHistory(
             core_runnable,
-            self.get_session_history, # Method to load/store session history
-            input_messages_key="user_input_combined", # Key for the user's current input
-            history_messages_key="chat_history", # Key for where history messages are injected into the prompt
+            self.get_session_history,
+            input_messages_key="user_input_combined",
+            history_messages_key="chat_history",
         )
         logger.info("LLMService initialized with LCEL RunnableWithMessageHistory and model %s.", "gemini-1.5-flash-latest")
 
     def get_session_history(self, session_id: str) -> ChatMessageHistory:
-        """Retrieves or creates an in-memory chat message history for a given session ID."""
         if session_id not in self.session_histories:
-            logger.info(f"Creating new chat history for session_id: {session_id}")
+            logger.info(f"SESSION_HISTORY ({session_id}): Creating new ChatMessageHistory.")
             self.session_histories[session_id] = ChatMessageHistory()
         else:
-            logger.info(f"Using existing chat history for session_id: {session_id}")
-        return self.session_histories[session_id]
+            logger.info(f"SESSION_HISTORY ({session_id}): Using existing ChatMessageHistory.")
+
+        history_obj = self.session_histories[session_id]
+        # Log message count before returning the history object
+        logger.debug(f"SESSION_HISTORY ({session_id}): Current message count before this turn: {len(history_obj.messages)}")
+        # For more detailed view of history (be cautious with logging full messages in prod)
+        # for i, msg in enumerate(history_obj.messages):
+        #    logger.debug(f"SESSION_HISTORY ({session_id}): Message {i}: type={type(msg).__name__}, content='{str(msg.content)[:50]}...'")
+        return history_obj
 
     def _prepare_input_with_image_context(self, user_input: str, image_notes: Optional[str]) -> str:
+        # ... (remains the same)
         if image_notes:
             logger.debug("Adding image context notes: %s", image_notes)
             return f"{user_input} [Image context: {image_notes}]"
@@ -86,13 +79,22 @@ class LLMService:
         combined_input = self._prepare_input_with_image_context(user_input, image_notes)
         logger.info("Generating non-streaming LCEL response for input: %.100s... (session: %s)", combined_input, conversation_id)
 
+        # The get_session_history method (called by RunnableWithMessageHistory) will log the state of history *before* this turn.
+        logger.debug(f"SESSION_HISTORY ({conversation_id}): Invoking runnable_with_history.ainvoke.")
+
         try:
-            # RunnableWithMessageHistory handles history internally based on session_id in config
             response_text = await self.runnable_with_history.ainvoke(
                 {"user_input_combined": combined_input},
                 config={"configurable": {"session_id": conversation_id}}
             )
             logger.info("Non-streaming LCEL response generated: %.100s... (session: %s)", response_text, conversation_id)
+
+            # After the invoke, RunnableWithMessageHistory will have called get_session_history again to save the new messages.
+            # The logging in get_session_history will show the updated message count for the *next* turn if it's called for the same session_id.
+            # For an immediate view of the updated history for *this* turn:
+            if conversation_id in self.session_histories:
+                 history_obj_after = self.session_histories[conversation_id]
+                 logger.debug(f"SESSION_HISTORY ({conversation_id}): Message count after this turn: {len(history_obj_after.messages)}")
             return response_text
         except Exception as e:
             logger.error("Error during LCEL runnable_with_history.ainvoke: %s (session: %s)", e, conversation_id, exc_info=True)
@@ -104,16 +106,24 @@ class LLMService:
         combined_input = self._prepare_input_with_image_context(user_input, image_notes)
         logger.info("Generating streaming LCEL response for input: %.100s... (session: %s)", combined_input, conversation_id)
 
+        # The get_session_history method (called by RunnableWithMessageHistory) will log the state of history *before* this turn.
+        logger.debug(f"SESSION_HISTORY ({conversation_id}): Invoking runnable_with_history.astream.")
+
         try:
-            # RunnableWithMessageHistory handles history internally based on session_id in config
             async for token in self.runnable_with_history.astream(
                 {"user_input_combined": combined_input},
                 config={"configurable": {"session_id": conversation_id}}
             ):
-                # token here is already a string due to StrOutputParser
                 if token:
                     yield token
             logger.info("Streaming LCEL response completed. (session: %s)", conversation_id)
+
+            # After the stream, RunnableWithMessageHistory will have called get_session_history again to save the new messages.
+            # For an immediate view of the updated history for *this* turn:
+            if conversation_id in self.session_histories:
+                 history_obj_after = self.session_histories[conversation_id]
+                 logger.debug(f"SESSION_HISTORY ({conversation_id}): Message count after this turn: {len(history_obj_after.messages)}")
+
         except Exception as e:
             logger.error("Error during LCEL runnable_with_history.astream: %s (session: %s)", e, conversation_id, exc_info=True)
             yield "Oh, wow. My LCEL (with History!) stream of consciousness just... stopped. Could this BE a server hiccup?"


### PR DESCRIPTION
- In `backend/app/services/llm_service.py`:
  - Enhanced logging within `get_session_history` to show when new chat histories are created or existing ones are reused, and to log the message count of the history being provided.
  - Added debug logs in `generate_response` and `async_generate_streaming_response` to indicate the state of history before and after calls to the LCEL runnable (by logging the message count from the history object associated with the current `conversation_id`).
  - All session history related logs now include the `session_id`.

This additional logging is intended to help diagnose issues with conversational memory by providing visibility into the lifecycle and state of `ChatMessageHistory` objects.