### PR TITLE
Here's the rewritten message:

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -25,18 +25,14 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
-/* frontend/src/app/globals.css - append this */
+/* frontend/src/app/globals.css - modify existing body.theme-chandler */
 body.theme-chandler {
-  background-image: url('/characters/chandler/background.svg'); /* Reference the SVG placeholder */
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-attachment: fixed; /* Optional: makes the background fixed during scroll */
-  /* Add a subtle overlay or blend mode if image is too distracting */
-  /* For example:
-  position: relative;
-  z-index: 0;
-  */
+  background-image: url('/characters/chandler/background.svg') !important; /* Path check + !important */
+  background-color: lightpink !important; /* Obvious fallback color for diagnostics */
+  background-size: cover !important;
+  background-position: center !important;
+  background-repeat: no-repeat !important;
+  background-attachment: fixed !important;
 }
 
 /* Ensure content is legible over the background, perhaps by adding a semi-transparent overlay to main content areas if needed */


### PR DESCRIPTION
fix: Add diagnostics for background theme application

- In `frontend/src/app/globals.css`:
  - Modified the `body.theme-chandler` class.
  - Added `!important` to all background-related properties (image, color, size, position, repeat, attachment).
  - Set `background-color: lightpink !important;` as an obvious fallback color.

This change is for diagnostic purposes to determine if the `theme-chandler` class is being correctly applied and if its CSS rules are active, or if there's an issue with the SVG image path or loading.