### PR TITLE
feat: Implement unified background and floating card UI

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -25,15 +25,17 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
-/* frontend/src/app/globals.css - modify existing body.theme-chandler */
+/* frontend/src/app/globals.css - comment out theme-chandler */
+/*
 body.theme-chandler {
-  background-image: url('/characters/chandler/background.svg') !important; /* Path check + !important */
-  background-color: lightpink !important; /* Obvious fallback color for diagnostics */
+  background-image: url('/characters/chandler/background.svg') !important;
+  background-color: lightpink !important;
   background-size: cover !important;
   background-position: center !important;
   background-repeat: no-repeat !important;
   background-attachment: fixed !important;
 }
+*/
 
 /* Ensure content is legible over the background, perhaps by adding a semi-transparent overlay to main content areas if needed */
 /* For example, if the main chat components had their own background:

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -17,8 +17,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      {/* Added 'theme-chandler' class and a base bg color that theme might override */}
-      <body className={`${inter.className} theme-chandler bg-gray-100 dark:bg-gray-900`}>
+      {/* Changed to slate, commented out theme-chandler */}
+      <body className={`${inter.className} bg-slate-100 dark:bg-slate-900 /* theme-chandler */`}>
         {children}
       </body>
     </html>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -65,12 +65,10 @@ export default function ChatPage() {
       <main className="flex-grow container mx-auto px-4 flex flex-col overflow-hidden">
         <ChatArea messages={messages} />
       </main>
-
-      {/* Wrapper for MessageInput - this needs a distinct background for shadow to pop */}
-      <div className="sticky bottom-0 left-0 right-0 z-10 bg-transparent"> {/* Make wrapper transparent */}
-        <div className="container mx-auto px-0 md:px-4"> {/* Inner container for padding */}
-            <MessageInput
-              input={input}
+      {/* Wrapper for MessageInput - set to transparent */}
+      <div className="sticky bottom-0 left-0 right-0 z-10 bg-transparent">
+        <div className="container mx-auto px-0 md:px-4">
+            <MessageInput input={input} handleInputChange={handleInputChange} handleSubmit={handleSubmit} />
               handleInputChange={handleInputChange}
           handleSubmit={handleSubmit}
           // isLoading={isLoading}

--- a/frontend/src/components/chat/CharacterSelector.tsx
+++ b/frontend/src/components/chat/CharacterSelector.tsx
@@ -18,29 +18,21 @@ const CharacterSelector = () => {
   const [selectedCharacterId, setSelectedCharacterId] = useState<string | null>('chandler');
 
   return (
-    <div className="bg-gray-200 dark:bg-gray-800 p-2 my-3 rounded-md shadow"> {/* Reduced padding and margin */}
-      <h2 className="text-lg font-semibold mb-2 text-center text-gray-800 dark:text-gray-200">Select a Character</h2> {/* Reduced margin, text size */}
-      <div className="flex justify-center space-x-3"> {/* Reduced space */}
+    // Applied card styling: bg, shadow, rounding. Added p-3 for internal padding.
+    <div className="bg-white dark:bg-slate-800 shadow-lg rounded-lg p-3 my-3">
+      <h2 className="text-lg font-semibold mb-2 text-center text-slate-700 dark:text-slate-300">Select a Character</h2>
+      <div className="flex justify-center space-x-3">
         {characters.map((char) => (
           <div
             key={char.id}
-            className={`p-1 rounded-lg cursor-pointer transition-all duration-200 ease-in-out transform hover:scale-105 flex flex-col items-center justify-center  // Added flex utilities
-                        ${selectedCharacterId === char.id ? 'ring-2 ring-blue-500 shadow-md' : 'opacity-70 hover:opacity-100'}`} // Reduced padding, shadow
+            // Selected item gets a ring, non-selected gets opacity effects
+            className={`p-1 rounded-lg cursor-pointer transition-all duration-200 ease-in-out transform hover:scale-105 flex flex-col items-center justify-center
+                        ${selectedCharacterId === char.id ? 'ring-2 ring-blue-500' : 'opacity-70 hover:opacity-100'}`}
             onClick={() => setSelectedCharacterId(char.id)}
-            role="button"
-            tabIndex={0}
-            aria-pressed={selectedCharacterId === char.id}
-            aria-label={`Select ${char.name}`}
+            role="button" tabIndex={0} aria-pressed={selectedCharacterId === char.id} aria-label={`Select ${char.name}`}
           >
-            <Image
-              src={char.avatarUrl}
-              alt={char.name}
-              width={60} // Reduced size
-              height={60} // Reduced size
-              className="rounded-full"
-              priority
-            />
-            <p className="text-center mt-1 text-xs text-gray-700 dark:text-gray-300">{char.name}</p> {/* Reduced margin and text size */}
+            <Image src={char.avatarUrl} alt={char.name} width={60} height={60} className="rounded-full" priority />
+            <p className="text-center mt-1 text-xs text-slate-600 dark:text-slate-400">{char.name}</p>
           </div>
         ))}
       </div>

--- a/frontend/src/components/chat/ChatArea.tsx
+++ b/frontend/src/components/chat/ChatArea.tsx
@@ -2,18 +2,16 @@
 "use client";
 
 import React, { useEffect, useRef } from 'react';
-import ChatMessageComponent, { Message as ChatMessageInterface } from './ChatMessage'; // Renamed to avoid conflict with 'ai' Message type
-import { Message as VercelAIMessage } from 'ai'; // Vercel AI SDK Message type
+import ChatMessageComponent, { Message as ChatMessageInterface } from './ChatMessage';
+import { Message as VercelAIMessage } from 'ai';
 
 interface ChatAreaProps {
-  messages: VercelAIMessage[]; // Messages from useChat hook
-  // Add other props like isLoading if needed for typing indicator
+  messages: VercelAIMessage[];
 }
 
 const ChatArea: React.FC<ChatAreaProps> = ({ messages }) => {
   const scrollableContainerRef = useRef<HTMLDivElement>(null);
 
-  // Scroll to bottom when new messages are added
   useEffect(() => {
     if (scrollableContainerRef.current) {
       scrollableContainerRef.current.scrollTop = scrollableContainerRef.current.scrollHeight;
@@ -23,12 +21,12 @@ const ChatArea: React.FC<ChatAreaProps> = ({ messages }) => {
   return (
     <div
       ref={scrollableContainerRef}
-        // Removed fixed height, should take space from parent flex container in page.tsx
-        className="flex-grow bg-white dark:bg-gray-700 p-4 my-0 rounded-md shadow overflow-y-auto"
+      // Applied card styling: bg, shadow, rounding. Added p-4 for internal padding.
+      className="flex-grow bg-white dark:bg-slate-800 shadow-lg rounded-lg p-4 my-0 overflow-y-auto"
     >
       {messages.length === 0 && (
         <div className="flex justify-center items-center h-full">
-          <p className="text-gray-400 dark:text-gray-500">
+          <p className="text-slate-400 dark:text-slate-500">
             No messages yet. Say hi to Chandler!
           </p>
         </div>
@@ -38,7 +36,7 @@ const ChatArea: React.FC<ChatAreaProps> = ({ messages }) => {
           id: msg.id,
           text: msg.content,
           sender: msg.role === 'user' ? 'user' : 'character',
-            characterName: msg.role !== 'user' ? 'Chandler' : undefined,
+          characterName: msg.role !== 'user' ? 'Chandler' : undefined,
         };
         return <ChatMessageComponent key={msg.id} message={adaptedMessage} />;
       })}

--- a/frontend/src/components/chat/MessageInput.tsx
+++ b/frontend/src/components/chat/MessageInput.tsx
@@ -1,20 +1,21 @@
 // frontend/src/components/chat/MessageInput.tsx
 "use client";
 
-import React from 'react'; // Removed useState as it's now controlled by useChat
+import React from 'react';
 
-// Icons remain the same
+// Icon definitions (defined once)
 const PaperclipIconSvg = (props: React.SVGProps<SVGSVGElement>) => (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M18.375 12.739l-7.693 7.693a4.5 4.5 0 01-6.364-6.364l10.94-10.94A3.375 3.375 0 1112.81 8.42l-7.693 7.693a.375.375 0 01-.53-.53l7.693-7.693a2.25 2.25 0 00-3.182-3.182L4.929 15.929a4.5 4.5 0 006.364 6.364l7.693-7.693a.375.375 0 01.53.53z" />
   </svg>
 );
+PaperclipIconSvg.displayName = 'PaperclipIcon';
+
 const PaperAirplaneIconSvg = (props: React.SVGProps<SVGSVGElement>) => (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5" />
     </svg>
 );
-PaperclipIconSvg.displayName = 'PaperclipIcon';
 PaperAirplaneIconSvg.displayName = 'PaperAirplaneIcon';
 
 
@@ -22,10 +23,9 @@ interface MessageInputProps {
   input: string;
   handleInputChange: (e: React.ChangeEvent<HTMLTextAreaElement> | React.ChangeEvent<HTMLInputElement>) => void;
   handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
-  // isLoading: boolean; // Optional: to disable input/button while processing
 }
 
-const MessageInput: React.FC<MessageInputProps> = ({ input, handleInputChange, handleSubmit /*, isLoading */ }) => {
+const MessageInput: React.FC<MessageInputProps> = ({ input, handleInputChange, handleSubmit }) => {
 
   const handleTextareaChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     handleInputChange(event);
@@ -46,7 +46,6 @@ const MessageInput: React.FC<MessageInputProps> = ({ input, handleInputChange, h
       event.preventDefault();
       const form = event.currentTarget.closest('form');
       if (form) {
-        // Create a new Event for submission
         const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
         form.dispatchEvent(submitEvent);
       }
@@ -56,34 +55,19 @@ const MessageInput: React.FC<MessageInputProps> = ({ input, handleInputChange, h
   return (
         <form
           onSubmit={onFormSubmit}
-          // Using new custom shadow and distinct background colors
-          className="bg-white dark:bg-input-bg-dark p-3 md:p-4 rounded-t-lg shadow-soft-lift-up border-t border-gray-200 dark:border-gray-700"
+          // Applied card background, specific shadow, top rounding, and top border.
+          className="bg-white dark:bg-slate-800 p-3 md:p-4 mt-auto shadow-soft-lift-up rounded-t-lg border-t border-slate-200 dark:border-slate-700"
         >
-          {/* ... rest of the component ... */}
           <div className="flex items-end space-x-2 md:space-x-3">
-            <button type="button" className="p-2 text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors" aria-label="Upload image (disabled)" disabled >
-              <PaperclipIconSvg className="w-5 h-5 md:w-6 md:h-6" />
-            </button>
+            <button type="button" className="p-2 text-slate-600 dark:text-slate-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors" aria-label="Upload image (disabled)" disabled > <PaperclipIconSvg className="w-5 h-5 md:w-6 md:h-6" /> </button>
             <textarea id="message-input-textarea" value={input} onChange={handleTextareaChange} onKeyDown={handleKeyDown} placeholder="Type your message..."
-              className="flex-grow p-2.5 text-sm md:text-base border-gray-300 dark:border-gray-600 rounded-lg focus:ring-blue-500 focus:border-blue-500 resize-none
-                         bg-white dark:bg-gray-700 text-gray-900 dark:text-white dark:placeholder-gray-400" // Textarea specific bg and text color
+              className="flex-grow p-2.5 text-sm md:text-base border-slate-300 dark:border-slate-600 rounded-lg focus:ring-blue-500 focus:border-blue-500 resize-none
+                         bg-slate-50 dark:bg-slate-700 text-slate-900 dark:text-white dark:placeholder-slate-400"
               rows={1} style={{ overflowY: 'hidden' }} />
-            <button type="submit" disabled={!input.trim()} className="p-2.5 text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors" aria-label="Send message" >
-              <PaperAirplaneIconSvg className="w-5 h-5 md:w-6 md:h-6" />
-            </button>
+            <button type="submit" disabled={!input.trim()} className="p-2.5 text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors" aria-label="Send message" > <PaperAirplaneIconSvg className="w-5 h-5 md:w-6 md:h-6" /> </button>
           </div>
         </form>
   );
 };
-// Icon definitions
-const PaperclipIconSvg = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M18.375 12.739l-7.693 7.693a4.5 4.5 0 01-6.364-6.364l10.94-10.94A3.375 3.375 0 1112.81 8.42l-7.693 7.693a.375.375 0 01-.53-.53l7.693-7.693a2.25 2.25 0 00-3.182-3.182L4.929 15.929a4.5 4.5 0 006.364 6.364l7.693-7.693a.375.375 0 01.53.53z" />
-  </svg>
-);
-const PaperAirplaneIconSvg = (props: React.SVGProps<SVGSVGElement>) => (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5" />
-    </svg>
-);
+
 export default MessageInput;

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -3,8 +3,9 @@ import React from 'react';
 
 const Header = () => {
   return (
-    <header className="bg-blue-600 dark:bg-blue-800 text-white p-4 shadow-md">
-      <h1 className="text-2xl font-bold">Chatterbox</h1>
+    // Changed to transparent, added bottom border
+    <header className="bg-transparent text-slate-900 dark:text-slate-100 p-4 border-b border-slate-200 dark:border-slate-700">
+      <h1 className="text-2xl font-bold text-center">Chatterbox</h1> {/* Centered title for now */}
     </header>
   );
 };


### PR DESCRIPTION
- UB1: Establish Unified Page Background & Reset Element Backgrounds
  - I set a unified page background (slate-100/dark:slate-900) in layout.tsx.
  - I commented out previous Chandler-specific theme CSS.
  - I reset backgrounds of Header, CharacterSelector, ChatArea, and MessageInput (form and its wrapper) to be transparent or blend with the new page background, preparing for card styling.
  - I adjusted text colors for contrast with new slate backgrounds.
  - I gave the textarea in MessageInput its own distinct background.

- UB2: Style Key Components as "Floating Cards"
  - I applied a consistent "card" style (bg-white dark:bg-slate-800, shadow-lg, rounded-lg) to CharacterSelector and ChatArea.
  - I styled MessageInput's form element with the card background, the custom `shadow-soft-lift-up` for a prominent floating effect at the bottom, top rounding (rounded-t-lg), and a top border.

This refactor aims to create a cleaner, more cohesive, and modern UI by establishing a single page background and having key interactive elements appear as "floating cards" on top of it.