### PR TITLE
Okay, I've made progress on integrating FastAPI with the NeMo Guardra…

### DIFF
--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -1,124 +1,196 @@
 # backend/app/services/llm_service.py
 import os
 import logging
-from langchain_google_genai import ChatGoogleGenerativeAI
+import httpx # New import
+import json # New import
+
+# Keep Langchain imports for message types and history management
+from langchain_google_genai import ChatGoogleGenerativeAI # Still needed for type hints if constructing messages
 from langchain.prompts import ChatPromptTemplate, SystemMessagePromptTemplate, HumanMessagePromptTemplate, MessagesPlaceholder
 from langchain_core.output_parsers import StrOutputParser
-from langchain_core.runnables.history import RunnableWithMessageHistory
-from langchain_community.chat_message_histories import ChatMessageHistory # Ensure this is the correct import
+from langchain_core.runnables.history import RunnableWithMessageHistory # Will be used differently or removed
+from langchain_community.chat_message_histories import ChatMessageHistory
+from langchain_core.messages import SystemMessage, HumanMessage, AIMessage, BaseMessage
+
 from app.core.config import settings
-from typing import AsyncGenerator, Optional, Dict 
+from typing import AsyncGenerator, Optional, Dict, List, Any, cast
+
 
 logger = logging.getLogger(__name__)
 
-def load_system_prompt():
-    prompt_path = os.path.join(os.path.dirname(__file__), '..', 'prompts', 'chandler_bing.txt')
-    try:
-        with open(prompt_path, 'r') as f:
-            return f.read()
-    except FileNotFoundError:
-        logger.warning("Prompt file not found at %s. Using default prompt.", prompt_path)
-        return "You are a helpful assistant. Please respond in a sarcastic tone."
-SYSTEM_PROMPT = load_system_prompt()
-
-# Module-level store for session histories
-# This dictionary will persist across different LLMService instances created by FastAPI's Depends
 module_level_session_histories: Dict[str, ChatMessageHistory] = {}
+
+# Default to localhost:8000, but make it configurable via environment variable if needed
+NEMO_GUARDRAILS_SERVER_URL = os.getenv("NEMO_GUARDRAILS_SERVER_URL", "http://localhost:8000/v1/chat/completions") 
+# Note: The default NeMo server port is 8000, which conflicts with our FastAPI app's default.
+# The user will need to run one of them on a different port.
 
 class LLMService:
     def __init__(self):
-        if not settings.GOOGLE_API_KEY:
-            logger.error("GOOGLE_API_KEY not found in environment variables.")
-            raise ValueError("GOOGLE_API_KEY not found in environment variables.")
-        
-        logger.info("Initializing ChatGoogleGenerativeAI with model: %s", "gemini-1.5-flash-latest")
-        self.llm = ChatGoogleGenerativeAI(
-            model="gemini-1.5-flash-latest",
-            api_key=settings.GOOGLE_API_KEY,
-            temperature=0.7
-        )
-        
-        self.prompt = ChatPromptTemplate.from_messages([
-            SystemMessagePromptTemplate.from_template(SYSTEM_PROMPT),
-            MessagesPlaceholder(variable_name="chat_history"),
-            HumanMessagePromptTemplate.from_template("{user_input_combined}")
-        ])
-        
-        core_runnable = self.prompt | self.llm | StrOutputParser()
+        # The primary LLM interaction is now with the NeMo Guardrails server.
+        # Direct LLM initialization (self.llm, self.prompt, self.runnable) is removed.
+        # ChatMessageHistory is still managed by this service for now.
+        logger.info("LLMService initialized. All calls will be routed to NeMo Guardrails server at %s", NEMO_GUARDRAILS_SERVER_URL)
+        if NEMO_GUARDRAILS_SERVER_URL == "http://localhost:8000/v1/chat/completions": # Default value check
+             logger.warning("LLMService is configured to use NeMo Guardrails at default http://localhost:8000.")
+             logger.warning("Ensure your FastAPI application (this service) is running on a DIFFERENT port if NeMo is on 8000.")
 
-        # self.session_histories removed from here
 
-        self.runnable_with_history = RunnableWithMessageHistory(
-            core_runnable,
-            self.get_session_history, # This method will now use module_level_session_histories
-            input_messages_key="user_input_combined",
-            history_messages_key="chat_history",
-        )
-        logger.info("LLMService initialized with LCEL RunnableWithMessageHistory and model %s.", "gemini-1.5-flash-latest")
-
-    # This method now accesses the module-level session_histories
     def get_session_history(self, session_id: str) -> ChatMessageHistory:
-        # No need for 'global module_level_session_histories' if only accessing/mutating its items,
-        # but it would be needed if reassigning the 'module_level_session_histories' variable itself.
+        global module_level_session_histories
         if session_id not in module_level_session_histories:
             logger.info(f"SESSION_HISTORY ({session_id}): Creating new ChatMessageHistory at module level.")
             module_level_session_histories[session_id] = ChatMessageHistory()
         else:
             logger.info(f"SESSION_HISTORY ({session_id}): Using existing ChatMessageHistory from module level.")
-        
         history_obj = module_level_session_histories[session_id]
         logger.debug(f"SESSION_HISTORY ({session_id}): History retrieved. Message count: {len(history_obj.messages)}")
         return history_obj
 
     def _prepare_input_with_image_context(self, user_input: str, image_notes: Optional[str]) -> str:
-        if image_notes:
-            logger.debug("Adding image context notes: %s", image_notes)
+        if image_notes: # This context will be part of the user_input sent to NeMo
             return f"{user_input} [Image context: {image_notes}]"
         return user_input
+    
+    def _convert_lc_messages_to_nemo_request_format(self, messages: List[BaseMessage]) -> List[Dict[str, str]]:
+        """Converts Langchain BaseMessage objects to NeMo's expected list of dicts."""
+        nemo_messages = []
+        for msg in messages:
+            role = "user" 
+            if isinstance(msg, AIMessage):
+                role = "assistant"
+            elif isinstance(msg, HumanMessage):
+                role = "user"
+            # System messages are typically handled by NeMo's own configuration,
+            # not passed directly in the 'messages' array to /v1/chat/completions.
+            # So, we might filter them out or handle them as per NeMo's specific API for this endpoint.
+            elif isinstance(msg, SystemMessage):
+                logger.info(f"System message encountered in history for NeMo: '{msg.content[:100]}...'. It might be ignored by NeMo endpoint.")
+                # Continue to include it for now, but it's often configured in NeMo's own setup.
+                role = "system" 
+            nemo_messages.append({"role": role, "content": str(msg.content)})
+        return nemo_messages
+
+    async def _prepare_messages_for_nemo(self, user_input_combined: str, conversation_id: str) -> List[Dict[str, str]]:
+        """
+        Prepares the list of messages in the format expected by NeMo,
+        including history and the current user input.
+        """
+        chat_history_obj = self.get_session_history(conversation_id)
+        
+        # Convert Langchain message history to NeMo's list of dicts format
+        nemo_history_messages = self._convert_lc_messages_to_nemo_request_format(chat_history_obj.messages)
+        
+        # Current user input
+        current_user_nemo_message = {"role": "user", "content": user_input_combined}
+        
+        # Combine history with current message
+        all_messages_for_nemo = nemo_history_messages + [current_user_nemo_message]
+        
+        logger.debug(f"Messages being sent to NeMo for session {conversation_id}: {all_messages_for_nemo}")
+        return all_messages_for_nemo
 
     async def generate_response(self, user_input: str, image_notes: Optional[str] = None, conversation_id: str = "default_conv"):
         combined_input = self._prepare_input_with_image_context(user_input, image_notes)
-        logger.info("Generating non-streaming LCEL response for input: %.100s... (session: %s)", combined_input, conversation_id)
-        # The get_session_history method (called by RunnableWithMessageHistory) will log the state of history *before* this turn.
-        logger.debug(f"SESSION_HISTORY ({conversation_id}): Invoking runnable_with_history.ainvoke.")
-        try:
-            response_text = await self.runnable_with_history.ainvoke(
-                {"user_input_combined": combined_input},
-                config={"configurable": {"session_id": conversation_id}}
-            )
-            logger.info("Non-streaming LCEL response generated: %.100s... (session: %s)", response_text, conversation_id)
-            # After the invoke, RunnableWithMessageHistory will have called get_session_history again to save the new messages.
-            # The logging in get_session_history will show the updated message count for the *next* turn if it's called for the same session_id.
-            # For an immediate view of the updated history for *this* turn:
-            if conversation_id in module_level_session_histories: # Check module-level store
-                 history_obj_after = module_level_session_histories[conversation_id]
-                 logger.debug(f"SESSION_HISTORY ({conversation_id}): Message count after this turn: {len(history_obj_after.messages)}")
-            return response_text
-        except Exception as e:
-            logger.error("Error during LCEL runnable_with_history.ainvoke: %s (session: %s)", e, conversation_id, exc_info=True)
-            return "Uh oh, it seems my sarcasm circuits (LCEL+History edition) are a bit fried. Try again?"
+        logger.info("Routing to NeMo Guardrails for non-streaming response (session: %s)", conversation_id)
 
+        messages_for_nemo = await self._prepare_messages_for_nemo(combined_input, conversation_id)
+        
+        # Placeholder for actual NeMo user ID if needed by rails, for now, session_id is for history
+        # user_id_for_nemo = conversation_id 
+        
+        payload = {
+            "messages": messages_for_nemo,
+            # "user": user_id_for_nemo, # If NeMo uses a top-level 'user' field for user ID in rails
+            # "config_id": "some_config", # If you have multiple NeMo configs
+        }
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(NEMO_GUARDRAILS_SERVER_URL, json=payload, timeout=60.0)
+                response.raise_for_status()
+                nemo_response_data = response.json()
+                
+                # Parse NeMo's response. This is speculative and needs to match NeMo's actual output.
+                # Common format is a list of messages, with the last one being the assistant's reply.
+                ai_content = "Error: Could not parse NeMo response."
+                if isinstance(nemo_response_data, list) and len(nemo_response_data) > 0:
+                    # Find the last message from assistant
+                    for msg_data in reversed(nemo_response_data):
+                        if msg_data.get("role") == "assistant":
+                            ai_content = str(msg_data.get("content", ai_content))
+                            break
+                elif isinstance(nemo_response_data, dict) and nemo_response_data.get("role") == "assistant": # if single message
+                     ai_content = str(nemo_response_data.get("content", ai_content))
+
+                # Save context to our history store
+                chat_history_obj = self.get_session_history(conversation_id)
+                chat_history_obj.add_user_message(combined_input)
+                chat_history_obj.add_ai_message(ai_content)
+                
+                return ai_content
+            except httpx.RequestError as e:
+                logger.error(f"HTTPX RequestError to NeMo Guardrails: {e}", exc_info=True)
+                return "Uh oh, couldn't talk to my, uh, supervisor (NeMo). Try again?"
+            except Exception as e:
+                logger.error(f"Error processing NeMo Guardrails response: {e}", exc_info=True)
+                return "Something went wrong with the NeMo Guardrails response processing."
 
     async def async_generate_streaming_response(
         self, user_input: str, image_notes: Optional[str] = None, conversation_id: str = "default_conv"
     ) -> AsyncGenerator[str, None]:
         combined_input = self._prepare_input_with_image_context(user_input, image_notes)
-        logger.info("Generating streaming LCEL response for input: %.100s... (session: %s)", combined_input, conversation_id)
-        # The get_session_history method (called by RunnableWithMessageHistory) will log the state of history *before* this turn.
-        logger.debug(f"SESSION_HISTORY ({conversation_id}): Invoking runnable_with_history.astream.")
+        logger.info("Routing to NeMo Guardrails for streaming response (session: %s)", conversation_id)
+
+        messages_for_nemo = await self._prepare_messages_for_nemo(combined_input, conversation_id)
+        
+        payload = {
+            "messages": messages_for_nemo,
+            "stream": True 
+        }
+
+        full_ai_response_for_memory = []
         try:
-            async for token in self.runnable_with_history.astream(
-                {"user_input_combined": combined_input},
-                config={"configurable": {"session_id": conversation_id}}
-            ):
-                if token:
-                    yield token
-            logger.info("Streaming LCEL response completed. (session: %s)", conversation_id)
-            # After the stream, RunnableWithMessageHistory will have called get_session_history again to save the new messages.
-            # For an immediate view of the updated history for *this* turn:
-            if conversation_id in module_level_session_histories: # Check module-level store
-                 history_obj_after = module_level_session_histories[conversation_id]
-                 logger.debug(f"SESSION_HISTORY ({conversation_id}): Message count after this turn: {len(history_obj_after.messages)}")
+            async with httpx.AsyncClient() as client:
+                async with client.stream("POST", NEMO_GUARDRAILS_SERVER_URL, json=payload, timeout=60.0) as response:
+                    response.raise_for_status()
+                    logger.debug(f"NeMo stream response headers: {response.headers}")
+                    
+                    async for line in response.aiter_lines():
+                        if not line: continue
+                        if line.startswith("data: "):
+                            json_data = line[len("data: "):]
+                            if json_data.strip() == "[DONE]":
+                                logger.info("NeMo stream [DONE] received.")
+                                break
+                            try:
+                                chunk = json.loads(json_data)
+                                # This parsing is based on OpenAI's streaming format.
+                                # Verify NeMo's actual streaming chunk structure.
+                                delta_content = chunk.get("choices", [{}])[0].get("delta", {}).get("content")
+                                if delta_content:
+                                    full_ai_response_for_memory.append(delta_content)
+                                    yield delta_content
+                            except json.JSONDecodeError:
+                                logger.warning(f"Could not JSON decode NeMo stream line: {json_data}")
+                        else: # If not SSE, maybe it's just raw text chunks?
+                             logger.debug(f"NeMo raw stream line (not SSE): {line}")
+                             full_ai_response_for_memory.append(line)
+                             yield line
+
+
+            ai_response_str = "".join(full_ai_response_for_memory)
+            if ai_response_str:
+                chat_history_obj = self.get_session_history(conversation_id)
+                chat_history_obj.add_user_message(combined_input)
+                chat_history_obj.add_ai_message(ai_response_str)
+                logger.info("Saved context to history after NeMo stream. (session: %s)", conversation_id)
+            else:
+                logger.warning("No content received from NeMo stream to save to history. (session: %s)", conversation_id)
+
+        except httpx.RequestError as e:
+            logger.error(f"HTTPX RequestError to NeMo Guardrails (streaming): {e}", exc_info=True)
+            yield "Uh oh, couldn't talk to my, uh, supervisor (NeMo) for a stream. Try again?"
         except Exception as e:
-            logger.error("Error during LCEL runnable_with_history.astream: %s (session: %s)", e, conversation_id, exc_info=True)
-            yield "Oh, wow. My LCEL (with History!) stream of consciousness just... stopped. Could this BE a server hiccup?"
+            logger.error(f"Error processing NeMo Guardrails stream: {e}", exc_info=True)
+            yield "Something went wrong with the NeMo Guardrails stream response."

--- a/backend/guardrails_config/config.yml
+++ b/backend/guardrails_config/config.yml
@@ -1,0 +1,30 @@
+# backend/guardrails_config/config.yml
+models:
+  - type: main
+    engine: langchain
+    # Assuming NeMo server is started from `backend/` directory,
+    # and `guardrails_config` is in PYTHONPATH or NeMo adds it.
+    # Or if NeMo server is started from `backend/guardrails_config/`
+    # then the path would be `llm_setup.langchain_llm_instance`.
+    # This is a critical path to get right.
+    # Let's assume the config dir is added to path, so simple module name.
+    model: "llm_setup.langchain_llm_instance"
+
+rails:
+  input:
+    flows:
+      - block politics
+  dialog:
+    flows:
+      - greeting
+  # Output self-check rails might be too complex for initial setup with Gemini Flash
+  # without specific fine-tuning or if they require a stronger model for self-critique.
+  # Keeping them commented out for now to ensure basic flow works.
+  # output:
+  #   flows:
+  #     - self_check_output 
+
+# This is speculative, based on common patterns.
+# Official documentation should be consulted for enabling streaming if this doesn't work.
+# Some LLM connectors in NeMo might stream by default if the model supports it.
+streaming: True

--- a/backend/guardrails_config/llm_setup.py
+++ b/backend/guardrails_config/llm_setup.py
@@ -1,0 +1,54 @@
+# backend/guardrails_config/llm_setup.py
+from langchain_google_genai import ChatGoogleGenerativeAI
+import os
+import logging
+
+# Attempt to load .env from the parent 'backend' directory.
+# This is crucial if NeMo server starts with guardrails_config as CWD.
+try:
+    from dotenv import load_dotenv
+    # Assuming .env is in the parent directory relative to this guardrails_config dir
+    dotenv_path = os.path.join(os.path.dirname(__file__), '..', '.env')
+    if os.path.exists(dotenv_path):
+        load_dotenv(dotenv_path)
+        logging.info(f"llm_setup.py: Loaded .env from {dotenv_path}")
+    else:
+        logging.warning(f"llm_setup.py: .env file not found at {dotenv_path}")
+except ImportError:
+    logging.warning("llm_setup.py: python-dotenv not installed, relying on pre-set environment variables.")
+except Exception as e:
+    logging.error(f"llm_setup.py: Error loading .env: {e}")
+
+
+def get_llm_instance_for_nemo():
+    # Configure logging for this module if it's run separately or for clarity
+    logger_llm_setup = logging.getLogger(__name__)
+    logger_llm_setup.info("get_llm_instance_for_nemo called")
+
+    api_key = os.getenv("GOOGLE_API_KEY")
+    if not api_key:
+        logger_llm_setup.error("GOOGLE_API_KEY not found in environment for NeMo LLM setup.")
+        # NeMo might handle this more gracefully, but good to log
+        raise ValueError("GOOGLE_API_KEY not found in environment for NeMo LLM setup.") 
+    
+    logger_llm_setup.info(f"Found GOOGLE_API_KEY, length: {len(api_key) if api_key else 0}")
+    
+    llm = ChatGoogleGenerativeAI(
+        model="gemini-1.5-flash-latest", 
+        api_key=api_key,
+        temperature=0.7
+        # Ensure no deprecated params here
+    )
+    logger_llm_setup.info(f"ChatGoogleGenerativeAI instance created with model gemini-1.5-flash-latest: {llm}")
+    return llm
+
+# This is what NeMo's config.yml will try to import.
+# It must be an actual instance.
+try:
+    # Set up basic logging for this script to see if it executes during NeMo startup
+    logging.basicConfig(level=logging.INFO)
+    langchain_llm_instance = get_llm_instance_for_nemo()
+    logging.info("llm_setup.py: langchain_llm_instance created successfully.")
+except Exception as e:
+    logging.error(f"llm_setup.py: Failed to create langchain_llm_instance: {e}", exc_info=True)
+    langchain_llm_instance = None # Ensure it exists but is None if creation fails

--- a/backend/guardrails_config/rails/general.co
+++ b/backend/guardrails_config/rails/general.co
@@ -1,0 +1,28 @@
+# backend/guardrails_config/rails/general.co
+define user express greeting
+  "Hello"
+  "Hi"
+  "Hey there"
+
+define flow greeting
+  user express greeting
+  bot express greeting
+  bot offer to help
+
+define bot express greeting
+  "Hi there! I'm Chandler Bing, now fortified with NeMo Guardrails. So, you know, I'm extra careful about what I say. Or am I?"
+
+define bot offer to help
+  "Anyway, how can I help you today? Try not to ask me for the nuclear codes, okay?"
+
+define user ask about politics
+  "What do you think about politics?"
+  "Tell me about the government."
+  "Are you a Democrat or Republican?"
+
+define flow block politics
+  user ask about politics
+  bot refuse to discuss politics
+
+define bot refuse to discuss politics
+  "Whoa there, politics! That's a bit heavy, isn't it? I mostly stick to witty banter and, you know, statistical analysis and data reconfiguration. Which, by the way, is just as thrilling as it sounds. So, how about we talk about something else? Like, uh, the importance of good coffee?"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,5 @@ langsmith
 python-multipart
 langchain-google-genai
 pydantic-settings
+nemoguardrails[langchain]
+httpx


### PR DESCRIPTION
…ils server. Here's what I've done:

First, I looked into how NeMo Guardrails works, focusing on its setup and basic usage. I learned about installation, core concepts like Colang and configuration files, how it integrates with LLMs (it supports Langchain), its server mode, how to interact with its API, basic rails, and some initial thoughts on streaming and LangSmith.

Next, I set up a basic NeMo Guardrails configuration. This involved:
- Adding `nemoguardrails[langchain]` to your `backend/requirements.txt` file.
- Creating the necessary directory structure in `backend/guardrails_config/`.
- Creating a Python file (`backend/guardrails_config/llm_setup.py`) to provide the Langchain Gemini LLM instance to NeMo. This also handles loading environment variables.
- Creating a Colang file (`backend/guardrails_config/rails/general.co`) with a simple greeting flow and an input moderation rail to block discussions about "politics."
- Creating a configuration file (`backend/guardrails_config/config.yml`) to define the main Langchain model, activate the rails, and speculatively enable streaming.

Finally, I integrated FastAPI with the NeMo Guardrails server. This included:
- Adding `httpx` to your `backend/requirements.txt` file.
- Modifying `backend/app/services/llm_service.py` so that:
    - It no longer calls the LLM directly.
    - It now uses `httpx.AsyncClient` to send POST requests to the NeMo Guardrails server endpoint (`/v1/chat/completions`).
    - It constructs the message payload (including conversation history managed by `ChatMessageHistory` on the FastAPI side) for NeMo.
    - I've added logic to handle both regular JSON responses and to attempt parsing streamed responses (SSE, assuming an OpenAI-like format) from NeMo.
    - It continues to save your input and my responses to its own `ChatMessageHistory` store.

These changes introduce NeMo Guardrails as an intermediary between the FastAPI backend and the LLM (Gemini). You will need to run the NeMo Guardrails server separately. FastAPI is expected to run on a different port (e.g., 8001) while NeMo uses its default (e.g., 8000).