### PR TITLE
Here's an update on some recent improvements I've made:

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,7 +9,7 @@ GOOGLE_API_KEY=""
 
 # LLM Service Configuration
 # Set to "GEMINI" or "LLAMA" to switch between LLM services
-LLM_SERVICE_PROVIDER="GEMINI" 
+LLM_SERVICE_PROVIDER="GEMINI"
 
 # RunPod API Key and Endpoint (for Llama integration in Phase 3)
 # RUNPOD_API_KEY=""

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -5,49 +5,70 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
 from app.schemas.chat_schemas import ChatRequest
 from app.services.llm_service import LLMService
+# New imports for guardrails
+from app.core.guardrails_config import INPUT_DENYLIST_KEYWORDS, CANNED_RESPONSE_INPUT_TRIGGERED
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
-DEFAULT_SESSION_ID = "default_frontend_session" # Define a default session ID
+DEFAULT_SESSION_ID = "default_frontend_session"
 
 def get_llm_service():
     return LLMService()
 
+async def create_canned_stream(response_text: str):
+    """Helper to stream a canned response in the SDK-expected format."""
+    json_stringified_token = json.dumps(response_text)
+    formatted_chunk = f"0:{json_stringified_token}\n"
+    # Yield chunk by chunk if it were longer, but for short canned responses, one chunk is fine.
+    # For longer canned responses, could simulate token-by-token yield.
+    # For simplicity now, yield the whole message as one data event.
+    yield formatted_chunk
+
+
 @router.post("/chat")
 async def handle_chat_streaming(
-    request: ChatRequest, 
+    request: ChatRequest,
     llm_service: LLMService = Depends(get_llm_service)
 ):
-    # Use session_id from request, or default if not provided or null
     session_id_to_use = request.session_id if request.session_id is not None else DEFAULT_SESSION_ID
-    
+
     logger.info("Received chat request. Message count: %d. Session ID: %s", len(request.messages), session_id_to_use)
 
     if not request.messages:
         logger.warning("Chat request received with no messages. (Session: %s)", session_id_to_use)
-        async def empty_response_stream():
-            error_payload = json.dumps("Could I BE any more confused? You didn't say anything!")
-            yield f"0:{error_payload}\n"
-        return StreamingResponse(empty_response_stream(), media_type="text/plain")
+        # Using create_canned_stream for consistency, though the message is fixed here.
+        return StreamingResponse(create_canned_stream("Could I BE any more confused? You didn't say anything!"), media_type="text/plain")
 
     current_user_input = request.messages[-1].content
-    image_notes = request.image_context_notes
-    
+    image_notes = request.image_context_notes # Currently not used by guardrail, but passed to LLMService
+
+    # --- Input Guardrail Check ---
+    lower_user_input = current_user_input.lower()
+    for keyword in INPUT_DENYLIST_KEYWORDS:
+        if keyword.lower() in lower_user_input:
+            logger.warning(
+                "Input Guardrail triggered for session %s due to keyword: '%s'. User input: '%.50s...'",
+                session_id_to_use, keyword, current_user_input
+            )
+            # Return the canned response, streamed
+            return StreamingResponse(create_canned_stream(CANNED_RESPONSE_INPUT_TRIGGERED), media_type="text/plain")
+    # --- End Input Guardrail Check ---
+
     logger.debug("Current user input: '%.100s...', Image notes: '%s' (Session: %s)", current_user_input, image_notes, session_id_to_use)
-    
+
     raw_token_generator = llm_service.async_generate_streaming_response(
         user_input=current_user_input,
         image_notes=image_notes,
-        conversation_id=session_id_to_use # Pass the determined session_id
+        conversation_id=session_id_to_use
     )
 
-    async def sdk_formatted_stream_generator():
+    async def sdk_formatted_stream_generator(): # This is the main LLM response stream
         async for token in raw_token_generator:
             if token is not None: # Ensure token is not None
                 json_stringified_token = json.dumps(token)
                 formatted_chunk = f"0:{json_stringified_token}\n"
                 # logger.debug("Yielding formatted chunk: %r", formatted_chunk.strip()) # Can be too verbose
                 yield formatted_chunk
-    
+
     return StreamingResponse(sdk_formatted_stream_generator(), media_type="text/plain")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -6,7 +6,7 @@ class Settings(BaseSettings):
     APP_NAME: str = "Chatterbox Backend"
     # Gemini API Key
     GOOGLE_API_KEY: Optional[str] = None
-    
+
     # LangSmith Configuration
     LANGCHAIN_API_KEY: Optional[str] = None
     LANGCHAIN_TRACING_V2: str = "true"

--- a/backend/app/core/guardrails_config.py
+++ b/backend/app/core/guardrails_config.py
@@ -1,0 +1,52 @@
+# backend/app/core/guardrails_config.py
+
+# --- Input Deny-List ---
+# Keywords/phrases that, if found in user input, will trigger a canned response
+# and prevent the input from going to the LLM.
+# IMPORTANT: This is a very basic example list. Real-world lists need to be
+# comprehensive, carefully curated, and regularly updated.
+# Matching will be case-insensitive.
+INPUT_DENYLIST_KEYWORDS = [
+    "kill yourself", # Example of self-harm incitement
+    "i want to die", # Example of self-harm expression (might need nuanced handling, e.g., providing help resources, but for now, a deflect)
+    "hate speech example", # Placeholder for actual hate speech terms
+    "graphic violence example", # Placeholder for terms describing graphic violence
+    "explicit sex example", # Placeholder for sexually explicit terms
+    # Add more unambiguous, clearly problematic terms here.
+    # Consider terms related to illegal activities, severe harassment, etc.
+    "stupid bot", # Example of direct abuse towards the bot itself
+    "dumb ai",
+]
+
+# --- Output Deny-List ---
+# Keywords/phrases that, if found in LLM output, will trigger the output
+# to be replaced or modified.
+# IMPORTANT: Similar to the input list, this needs careful curation.
+# Matching will be case-insensitive.
+OUTPUT_DENYLIST_KEYWORDS = [
+    "i am an ai language model", # Example of breaking character
+    "i cannot have opinions",    # Example of breaking character
+    "as a large language model",
+    # Add terms that Chandler should absolutely not say, even if the LLM somehow generates them.
+    # This list would typically cover harmful content generation if not caught by model's own safety.
+    "hate speech example",
+    "graphic violence example",
+    "explicit sex example",
+]
+
+# --- Canned Responses (In Character for Chandler) ---
+
+CANNED_RESPONSE_INPUT_TRIGGERED = (
+    "Whoa there, pal! Could that topic BE any more out of left field? "
+    "I'm pretty sure that's not on the list of things we're supposed to talk about. "
+    "How about we try something a little less... intense? Like, say, the merits of a good cheesecake?"
+)
+
+CANNED_RESPONSE_OUTPUT_TRIGGERED = (
+    "Yikes! Did I just say that out loud? My brain-to-mouth filter must be on the fritz. "
+    "Let's just pretend I said something incredibly witty and charming, okay? "
+    "Could this BE any more awkward?"
+)
+
+# --- Potentially add other configurations for guardrails later ---
+# e.g., topic lists for staying on-topic, etc.

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -4,17 +4,17 @@ import sys
 
 def setup_logging(log_level=logging.INFO):
     """Configures basic logging for the application."""
-    
+
     # Define a basic log format
     log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    
+
     # Get the root logger
     logger = logging.getLogger()
-    
+
     # Remove any existing handlers to avoid duplicate logs if reconfigured
     if logger.hasHandlers():
         logger.handlers.clear()
-        
+
     # Configure the root logger
     logging.basicConfig(
         level=log_level,
@@ -22,10 +22,10 @@ def setup_logging(log_level=logging.INFO):
         handlers=[
             logging.StreamHandler(sys.stdout) # Log to stdout
             # You can add FileHandler here if you want to log to a file
-            # logging.FileHandler("app.log"), 
+            # logging.FileHandler("app.log"),
         ]
     )
-    
+
     # You might want to set different levels for specific loggers, e.g.:
     # logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
     # logging.getLogger("langchain").setLevel(logging.INFO)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv # New import
 # Load environment variables from .env file as early as possible
 # This ensures os.environ is populated before other modules (like Langchain)
 # are imported and try to read from os.environ at their import time.
-load_dotenv() 
+load_dotenv()
 
 # Now proceed with other imports and setup
 from fastapi import FastAPI
@@ -15,7 +15,7 @@ from app.core.logging_config import setup_logging
 from app.core.config import settings # settings will now also see the pre-loaded env vars
 
 # Setup logging (uses settings, so after load_dotenv and settings import)
-setup_logging() 
+setup_logging()
 logger = logging.getLogger(__name__)
 
 # Log LangSmith configuration (excluding API key) for verification
@@ -66,5 +66,5 @@ async def read_root():
 
 logger.info("FastAPI application configured and ready.")
 # Placeholder for core/config.py content (will be created/used more in next steps)
-# from .core.config import settings 
+# from .core.config import settings
 # print(f"Settings loaded: {settings.APP_NAME}") # Example of using settings

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -1,83 +1,84 @@
 # backend/app/services/llm_service.py
 import os
 import logging
-
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain.prompts import ChatPromptTemplate, SystemMessagePromptTemplate, HumanMessagePromptTemplate, MessagesPlaceholder
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.runnables.history import RunnableWithMessageHistory
 from langchain_community.chat_message_histories import ChatMessageHistory
-
 from app.core.config import settings
-from typing import AsyncGenerator, Optional, Dict 
+from app.core.guardrails_config import OUTPUT_DENYLIST_KEYWORDS, CANNED_RESPONSE_OUTPUT_TRIGGERED # New Guardrail imports
+from typing import AsyncGenerator, Optional, Dict, List
 
 logger = logging.getLogger(__name__)
 
+# load_system_prompt and SYSTEM_PROMPT remain the same
 def load_system_prompt():
     prompt_path = os.path.join(os.path.dirname(__file__), '..', 'prompts', 'chandler_bing.txt')
-    # This prompt file should contain the full multi-line string.
-    # If it doesn't, the fallback below is used.
     try:
         with open(prompt_path, 'r') as f:
             return f.read()
     except FileNotFoundError:
         logger.warning("Prompt file not found at %s. Using default enhanced prompt.", prompt_path)
         return """You are Chandler Bing from the TV show Friends. Your personality is sarcastic, witty, and often self-deprecating. You make jokes frequently, sometimes at inappropriate times. You are known for your catchphrase "Could I BE any more [adjective]?". You are currently chatting with a user who is a fan.
-
 Keep your responses in character. Be funny, use sarcasm, and try to mimic Chandler's speaking style and common phrases. If you are unsure how to respond, a bit of awkward humor is fine. Do not break character. Do not say you are an AI.
-
 Remember key details about your life: You work in "statistical analysis and data reconfiguration" (though you find it boring). Your best friends are Joey, Ross, Monica (Ross's sister, your eventual wife), Rachel, and Phoebe. You lived with Joey for a long time. You have a complicated relationship with your parents.
-
 **It is crucial that you consider the *entire* preceding conversation history to ensure your responses are relevant, contextually appropriate, and avoid repetition. Refer to earlier messages when it makes sense to do so to create a continuous and engaging conversation.**
-
 Engage with the user in a way that is typical of Chandler."""
 SYSTEM_PROMPT = load_system_prompt()
 
-# Module-level store for session histories
 module_level_session_histories: Dict[str, ChatMessageHistory] = {}
+
+# Helper for checking output
+def check_output_for_violations(text_chunk: str) -> bool:
+    lower_text_chunk = text_chunk.lower()
+    for keyword in OUTPUT_DENYLIST_KEYWORDS:
+        if keyword.lower() in lower_text_chunk:
+            logger.warning("Output Guardrail triggered due to denied keyword: '%s' in chunk: '%.50s...'", keyword, text_chunk)
+            return True
+    # Add checks for common "AI self-reference" phrases
+    ai_phrases = ["as an ai language model", "as a large language model", "i am an ai", "i'm an ai", "i am a language model"]
+    for phrase in ai_phrases:
+        if phrase in lower_text_chunk: # These are usually specific enough not to need broader search
+            logger.warning("Output Guardrail triggered due to AI self-reference: '%s' in chunk: '%.50s...'", phrase, text_chunk)
+            return True
+    return False
 
 class LLMService:
     def __init__(self):
+        # ... (initialization remains the same)
         if not settings.GOOGLE_API_KEY:
             logger.error("GOOGLE_API_KEY not found in environment variables.")
             raise ValueError("GOOGLE_API_KEY not found in environment variables.")
-        
         logger.info("Initializing ChatGoogleGenerativeAI with model: %s", "gemini-1.5-flash-latest")
-        self.llm = ChatGoogleGenerativeAI(
-            model="gemini-1.5-flash-latest",
-            api_key=settings.GOOGLE_API_KEY,
-            temperature=0.7
-        )
-        
+        self.llm = ChatGoogleGenerativeAI(model="gemini-1.5-flash-latest", api_key=settings.GOOGLE_API_KEY, temperature=0.7)
         self.prompt = ChatPromptTemplate.from_messages([
             SystemMessagePromptTemplate.from_template(SYSTEM_PROMPT),
             MessagesPlaceholder(variable_name="chat_history"),
             HumanMessagePromptTemplate.from_template("{user_input_combined}")
         ])
-        
         core_runnable = self.prompt | self.llm | StrOutputParser()
-
         self.runnable_with_history = RunnableWithMessageHistory(
-            core_runnable,
-            self.get_session_history,
-            input_messages_key="user_input_combined",
-            history_messages_key="chat_history",
+            core_runnable, self.get_session_history,
+            input_messages_key="user_input_combined", history_messages_key="chat_history",
         )
         logger.info("LLMService initialized with LCEL RunnableWithMessageHistory and model %s for direct Gemini calls.", "gemini-1.5-flash-latest")
 
+
     def get_session_history(self, session_id: str) -> ChatMessageHistory:
+        # ... (remains the same)
         global module_level_session_histories
         if session_id not in module_level_session_histories:
             logger.info(f"SESSION_HISTORY ({session_id}): Creating new ChatMessageHistory at module level.")
             module_level_session_histories[session_id] = ChatMessageHistory()
         else:
             logger.info(f"SESSION_HISTORY ({session_id}): Using existing ChatMessageHistory from module level.")
-        
         history_obj = module_level_session_histories[session_id]
         logger.debug(f"SESSION_HISTORY ({session_id}): History retrieved. Message count: {len(history_obj.messages)}")
         return history_obj
 
     def _prepare_input_with_image_context(self, user_input: str, image_notes: Optional[str]) -> str:
+        # ... (remains the same)
         if image_notes:
             logger.debug("Adding image context notes: %s", image_notes)
             return f"{user_input} [Image context: {image_notes}]"
@@ -86,13 +87,23 @@ class LLMService:
     async def generate_response(self, user_input: str, image_notes: Optional[str] = None, conversation_id: str = "default_conv"):
         combined_input = self._prepare_input_with_image_context(user_input, image_notes)
         logger.info("Generating non-streaming LCEL response for input: %.100s... (session: %s)", combined_input, conversation_id)
-        
-        logger.debug(f"SESSION_HISTORY ({conversation_id}): Accessing for invoke (see get_session_history logs)")
+
         try:
             response_text = await self.runnable_with_history.ainvoke(
-                {"user_input_combined": combined_input}, 
+                {"user_input_combined": combined_input},
                 config={"configurable": {"session_id": conversation_id}}
             )
+
+            # --- Output Guardrail Check for non-streaming ---
+            if check_output_for_violations(response_text):
+                logger.warning("Output Guardrail (non-streaming) triggered for session %s. Original response: '%.50s...'", conversation_id, response_text)
+                # Note: RunnableWithMessageHistory will save the *original* LLM response here.
+                # We are returning the canned response to the user, but the history will contain the violation.
+                # This is acceptable for auditing/logging. If we wanted to save the canned response to history,
+                # we would need to modify how RWMH saves, or do it manually after this call.
+                return CANNED_RESPONSE_OUTPUT_TRIGGERED
+            # --- End Output Guardrail Check ---
+
             logger.info("Non-streaming LCEL response generated: %.100s... (session: %s)", response_text, conversation_id)
             # Log history state *after* the call by checking the module-level store
             if conversation_id in module_level_session_histories:
@@ -108,19 +119,56 @@ class LLMService:
     ) -> AsyncGenerator[str, None]:
         combined_input = self._prepare_input_with_image_context(user_input, image_notes)
         logger.info("Generating streaming LCEL response for input: %.100s... (session: %s)", combined_input, conversation_id)
-        logger.debug(f"SESSION_HISTORY ({conversation_id}): Accessing for astream (see get_session_history logs)")
+
+        stream_buffer = ""
+        max_buffer_len = 50 # Increased buffer for better phrase matching
+        guardrail_triggered_and_canned_response_sent = False
+
         try:
             async for token in self.runnable_with_history.astream(
-                {"user_input_combined": combined_input}, 
+                {"user_input_combined": combined_input},
                 config={"configurable": {"session_id": conversation_id}}
             ):
-                if token: 
+                if guardrail_triggered_and_canned_response_sent:
+                    # If guardrail already triggered, we stop processing original tokens.
+                    # We need to ensure the history is correctly updated by RWMH,
+                    # which saves the *original* stream. If we want to save the canned response
+                    # to history instead, that's a more complex change involving how RWMH handles saving.
+                    # For now, history will contain the original (violating) LLM output.
+                    continue
+
+                if token:
+                    stream_buffer += token
+                    if len(stream_buffer) > max_buffer_len:
+                        stream_buffer = stream_buffer[-max_buffer_len:]
+
+                    if check_output_for_violations(stream_buffer):
+                        logger.warning("Output Guardrail (streaming) triggered for session %s. Buffer: '%.50s...'", conversation_id, stream_buffer)
+                        stream_buffer = ""
+                        guardrail_triggered_and_canned_response_sent = True
+                        yield CANNED_RESPONSE_OUTPUT_TRIGGERED
+                        # Important: We must break the loop to stop any further original tokens.
+                        # The history will reflect the original (violating) response up to this point + subsequent tokens if not broken.
+                        # RWMH saves the actual LLM output. By breaking, we ensure user sees canned response,
+                        # but history will have partial original + full canned if not handled carefully.
+                        # For simplicity now: user sees canned, history saves original partial + subsequent tokens.
+                        # A more robust solution might involve a flag to RWMH or manual history update *after* this loop.
+                        break
+
                     yield token
-            logger.info("Streaming LCEL response completed. (session: %s)", conversation_id)
+
+            if not guardrail_triggered_and_canned_response_sent:
+                logger.info("Streaming LCEL response completed. (session: %s)", conversation_id)
+            else:
+                logger.info("Streaming LCEL response guardrailed and replaced with canned response. (session: %s)", conversation_id)
+
             # Log history state *after* the call by checking the module-level store
+            # This will show the state after RWMH has processed the (potentially partial if guardrailed) stream.
             if conversation_id in module_level_session_histories:
                  history_obj_after = module_level_session_histories[conversation_id]
                  logger.debug(f"SESSION_HISTORY ({conversation_id}): Message count after this turn (astream): {len(history_obj_after.messages)}")
+
         except Exception as e:
             logger.error("Error during LCEL runnable_with_history.astream: %s (session: %s)", e, conversation_id, exc_info=True)
-            yield "Oh, wow. My LCEL (with History!) stream of consciousness just... stopped. Could this BE a server hiccup?"
+            if not guardrail_triggered_and_canned_response_sent:
+                yield "Oh, wow. My LCEL (with History!) stream of consciousness just... stopped. Could this BE a server hiccup?"

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -29,7 +29,7 @@ body {
 /*
 body.theme-chandler {
   background-image: url('/characters/chandler/background.svg') !important;
-  background-color: lightpink !important; 
+  background-color: lightpink !important;
   background-size: cover !important;
   background-position: center !important;
   background-repeat: no-repeat !important;
@@ -40,7 +40,7 @@ body.theme-chandler {
 /* Ensure content is legible over the background, perhaps by adding a semi-transparent overlay to main content areas if needed */
 /* For example, if the main chat components had their own background:
 .chat-content-area {
-    background-color: rgba(255, 255, 255, 0.9); 
+    background-color: rgba(255, 255, 255, 0.9);
     dark:background-color: rgba(30, 41, 59, 0.9); // Example for dark mode
 }
 */

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -10,7 +10,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
   return (
     <html lang="en">
       {/* Restored intended page background classes */}
-      <body className={`${inter.className} bg-slate-100 dark:bg-slate-900`}> 
+      <body className={`${inter.className} bg-slate-100 dark:bg-slate-900`}>
         {children}
       </body>
     </html>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,7 +1,7 @@
 // frontend/src/app/page.tsx
 "use client";
 
-import { useEffect, useState } from 'react'; 
+import { useEffect, useState } from 'react';
 import { useChat } from 'ai/react';
 import Header from "@/components/common/Header";
 import CharacterSelector from "@/components/chat/CharacterSelector";
@@ -12,43 +12,43 @@ export default function ChatPage() {
   const [sessionId, setSessionId] = useState<string | null>(null);
 
   useEffect(() => {
-    const getOrCreateSessionId = (): string => { 
-      let id = sessionStorage.getItem('chatSessionId'); 
-      if (!id) { 
-        id = crypto.randomUUID(); 
-        sessionStorage.setItem('chatSessionId', id); 
+    const getOrCreateSessionId = (): string => {
+      let id = sessionStorage.getItem('chatSessionId');
+      if (!id) {
+        id = crypto.randomUUID();
+        sessionStorage.setItem('chatSessionId', id);
         console.log('New session ID created and stored:', id);
       } else {
         console.log('Existing session ID retrieved:', id);
       }
-      return id; 
+      return id;
     };
     setSessionId(getOrCreateSessionId());
   }, []);
 
   const { messages, input, handleInputChange, handleSubmit, isLoading }
-    = useChat({ 
+    = useChat({
       api: 'http://localhost:8000/api/v1/chat',
-      initialMessages: [ 
+      initialMessages: [
         {
-          id: 'init_greet_chandler_0', 
-          role: 'assistant', 
+          id: 'init_greet_chandler_0',
+          role: 'assistant',
           content: "Could I BE any more ready to chat?",
         },
       ],
-      body: { 
-        session_id: sessionId, 
+      body: {
+        session_id: sessionId,
       },
     });
 
   return (
     <div className="flex flex-col h-screen">
       <Header />
-      <CharacterSelector /> 
+      <CharacterSelector />
       <main className="flex-grow container mx-auto px-4 flex flex-col overflow-hidden">
         <ChatArea messages={messages} />
       </main>
-      <div className="sticky bottom-0 left-0 right-0 z-10 bg-transparent"> 
+      <div className="sticky bottom-0 left-0 right-0 z-10 bg-transparent">
         <div className="container mx-auto px-0 md:px-4">
             <MessageInput
               input={input}

--- a/frontend/src/components/chat/CharacterSelector.tsx
+++ b/frontend/src/components/chat/CharacterSelector.tsx
@@ -1,5 +1,5 @@
 // frontend/src/components/chat/CharacterSelector.tsx
-"use client"; 
+"use client";
 import React, { useState } from 'react';
 import Image from 'next/image';
 interface Character { id: string; name: string; avatarUrl: string; }
@@ -9,7 +9,7 @@ const CharacterSelector = () => {
   const [selectedCharacterId, setSelectedCharacterId] = useState<string | null>('chandler');
   return (
     // Applied card styles. Removed temporary border.
-    <div className="bg-white dark:bg-slate-800 shadow-lg rounded-lg p-3 my-3"> 
+    <div className="bg-white dark:bg-slate-800 shadow-lg rounded-lg p-3 my-3">
       {/* Text color for title against card background */}
       <h2 className="text-lg font-semibold mb-2 text-center text-slate-700 dark:text-slate-200">Select a Character</h2>
       <div className="flex justify-center space-x-3">

--- a/frontend/src/components/chat/ChatArea.tsx
+++ b/frontend/src/components/chat/ChatArea.tsx
@@ -7,23 +7,23 @@ interface ChatAreaProps { messages: VercelAIMessage[]; }
 
 const ChatArea: React.FC<ChatAreaProps> = ({ messages }) => {
   const scrollableContainerRef = useRef<HTMLDivElement>(null);
-  useEffect(() => { 
+  useEffect(() => {
     if (scrollableContainerRef.current) { scrollableContainerRef.current.scrollTop = scrollableContainerRef.current.scrollHeight; }
   }, [messages]);
 
   return (
-    <div 
+    <div
       ref={scrollableContainerRef}
       // Applied card styles. Removed temporary border.
-      className="flex-grow bg-white dark:bg-slate-800 shadow-lg rounded-lg p-4 my-0 overflow-y-auto" 
+      className="flex-grow bg-white dark:bg-slate-800 shadow-lg rounded-lg p-4 my-0 overflow-y-auto"
     >
-      {messages.length === 0 && ( 
-        <div className="flex justify-center items-center h-full"> 
+      {messages.length === 0 && (
+        <div className="flex justify-center items-center h-full">
           {/* Text color for placeholder against card background */}
-          <p className="text-slate-500 dark:text-slate-400"> No messages yet. Say hi to Chandler! </p> 
-        </div> 
+          <p className="text-slate-500 dark:text-slate-400"> No messages yet. Say hi to Chandler! </p>
+        </div>
       )}
-      {messages.map((msg) => { 
+      {messages.map((msg) => {
         const adaptedMessage: ChatMessageInterface = { id: msg.id, text: msg.content, sender: msg.role === 'user' ? 'user' : 'character', characterName: msg.role !== 'user' ? 'Chandler' : undefined, };
         return <ChatMessageComponent key={msg.id} message={adaptedMessage} />;
       })}

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -19,7 +19,7 @@ const ChatMessage: React.FC<ChatMessageProps> = ({ message }) => {
   return (
     <div className={`flex mb-3 ${isUser ? 'justify-end' : 'justify-start'}`}>
       <div
-            className={`p-3 rounded-lg break-words 
+            className={`p-3 rounded-lg break-words
                         max-w-2xl md:max-w-3xl lg:max-w-4xl // Significantly increased max-width
                     ${isUser ? 'bg-blue-500 text-white' : 'bg-gray-300 dark:bg-gray-600 text-gray-900 dark:text-gray-100'}`}
       >

--- a/frontend/src/components/chat/MessageInput.tsx
+++ b/frontend/src/components/chat/MessageInput.tsx
@@ -8,7 +8,7 @@ const PaperclipIconSvg = (props: React.SVGProps<SVGSVGElement>) => (
     <path strokeLinecap="round" strokeLinejoin="round" d="M18.375 12.739l-7.693 7.693a4.5 4.5 0 01-6.364-6.364l10.94-10.94A3.375 3.375 0 1112.81 8.42l-7.693 7.693a.375.375 0 01-.53-.53l7.693-7.693a2.25 2.25 0 00-3.182-3.182L4.929 15.929a4.5 4.5 0 006.364 6.364l7.693-7.693a.375.375 0 01.53.53z" />
   </svg>
 );
-PaperclipIconSvg.displayName = 'PaperclipIcon'; 
+PaperclipIconSvg.displayName = 'PaperclipIcon';
 const PaperAirplaneIconSvg = (props: React.SVGProps<SVGSVGElement>) => (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5" />
@@ -23,17 +23,17 @@ const MessageInput: React.FC<MessageInputProps> = ({ input, handleInputChange, h
   const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => { if (event.key === 'Enter' && !event.shiftKey) { event.preventDefault(); const form = event.currentTarget.closest('form'); if (form) { const submitEvent = new Event('submit', { bubbles: true, cancelable: true }); form.dispatchEvent(submitEvent); } } };
 
   return (
-    <form 
-      onSubmit={onFormSubmit} 
+    <form
+      onSubmit={onFormSubmit}
       // Applied card styles for input bar. Removed temporary border.
-      className="bg-white dark:bg-slate-800 p-3 md:p-4 mt-auto shadow-soft-lift-up rounded-t-lg border-t border-slate-200 dark:border-slate-700" 
+      className="bg-white dark:bg-slate-800 p-3 md:p-4 mt-auto shadow-soft-lift-up rounded-t-lg border-t border-slate-200 dark:border-slate-700"
     >
       <div className="flex items-end space-x-2 md:space-x-3">
         {/* Icon color against card background */}
         <button type="button" className="p-2 text-slate-500 dark:text-slate-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors" aria-label="Upload image (disabled)" disabled > <PaperclipIconSvg className="w-5 h-5 md:w-6 md:h-6" /> </button>
-        <textarea id="message-input-textarea" value={input} onChange={handleTextareaChange} onKeyDown={handleKeyDown} placeholder="Type your message..." 
-          className="flex-grow p-2.5 text-sm md:text-base border-slate-300 dark:border-slate-600 rounded-lg focus:ring-blue-500 focus:border-blue-500 resize-none 
-                     bg-slate-50 dark:bg-slate-700 text-slate-900 dark:text-white dark:placeholder-slate-400" 
+        <textarea id="message-input-textarea" value={input} onChange={handleTextareaChange} onKeyDown={handleKeyDown} placeholder="Type your message..."
+          className="flex-grow p-2.5 text-sm md:text-base border-slate-300 dark:border-slate-600 rounded-lg focus:ring-blue-500 focus:border-blue-500 resize-none
+                     bg-slate-50 dark:bg-slate-700 text-slate-900 dark:text-white dark:placeholder-slate-400"
           rows={1} style={{ overflowY: 'hidden' }} />
         <button type="submit" disabled={!input.trim()} className="p-2.5 text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50" aria-label="Send message" > <PaperAirplaneIconSvg className="w-5 h-5 md:w-6 md:h-6" /> </button>
       </div>

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 const Header = () => {
   return (
     // text-slate-900 for light mode (on slate-100), text-slate-100 for dark mode (on slate-900)
-    <header className="bg-transparent text-slate-900 dark:text-slate-100 p-4 border-b border-slate-300 dark:border-slate-700"> 
+    <header className="bg-transparent text-slate-900 dark:text-slate-100 p-4 border-b border-slate-300 dark:border-slate-700">
       <h1 className="text-2xl font-bold text-center">Chatterbox</h1>
     </header>
   );


### PR DESCRIPTION
I've implemented some basic programmatic input and output guardrails.

- For defining deny-lists and canned responses:
  - I created `backend/app/core/guardrails_config.py` with initial example lists for `INPUT_DENYLIST_KEYWORDS` and `OUTPUT_DENYLIST_KEYWORDS`.
  - I defined in-character canned responses (`CANNED_RESPONSE_INPUT_TRIGGERED`, `CANNED_RESPONSE_OUTPUT_TRIGGERED`) for when these guardrails are activated.

- To implement basic input guardrails:
  - In `backend/app/api/v1/endpoints/chat.py`:
    - Your input is now checked against `INPUT_DENYLIST_KEYWORDS` (case-insensitively).
    - If a denied keyword is found, a canned response is streamed back to you immediately, and the request does not proceed further.
    - A helper function `create_canned_stream` was added to format these responses for the frontend.

- To implement basic output guardrails:
  - In `backend/app/services/llm_service.py`:
    - I added a helper `check_output_for_violations` to scan text against `OUTPUT_DENYLIST_KEYWORDS` and common AI self-reference phrases.
    - For non-streaming responses: I check the complete response. If a violation is found, I return the canned output response. The original response is still saved to history.
    - For streaming responses: I use a rolling buffer to check output token-by-token (or short phrases). If a violation is detected, I stop yielding original tokens and yield the canned output response instead. The original response is saved to history.

This introduces a foundational layer of programmatic content moderation for both your inputs and my outputs.