### PR TITLE
fix: Adjust cache-dependency-path for Node.js in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,10 @@ jobs:
       - name: Setup Node.js for Frontend Linting
         uses: actions/setup-node@v4
         with:
-          node-version: '20' # Using Node.js 20 as specified in user's plan
+              node-version: '20'
           cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
+              # Changed cache-dependency-path to a glob pattern
+              cache-dependency-path: '**/package-lock.json'
 
       - name: Install Frontend Dependencies & Lint
         working-directory: ./frontend


### PR DESCRIPTION
- In `.github/workflows/ci.yml`:
  - Changed `cache-dependency-path` in the "Setup Node.js for Frontend Linting" step from `frontend/package-lock.json` to `'**/package-lock.json'`.

This change uses a glob pattern to hopefully make the path resolution for `package-lock.json` more robust, aiming to fix the "unable to cache dependencies" error you previously encountered in this step.